### PR TITLE
Add XRd Helm charts v1.0.0-beta.1

### DIFF
--- a/.github/config/ct.yml
+++ b/.github/config/ct.yml
@@ -1,0 +1,1 @@
+validate-maintainers: false

--- a/.github/config/ct.yml
+++ b/.github/config/ct.yml
@@ -1,1 +1,3 @@
+excluded-charts: xrd-common
+lint-conf: .github/config/yamllint.yml
 validate-maintainers: false

--- a/.github/config/yamllint.yml
+++ b/.github/config/yamllint.yml
@@ -1,0 +1,3 @@
+rules:
+  indentation: disable
+  line-length: disable

--- a/.github/config/yamllint.yml
+++ b/.github/config/yamllint.yml
@@ -1,3 +1,25 @@
+---
 rules:
-  indentation: disable
-  line-length: disable
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
+  comments:
+    require-starting-space: false
+    min-spaces-from-content: 2
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start: disable
+  empty-lines: enable
+  hyphens: enable
+  indentation:
+    spaces: consistent
+    indent-sequences: whatever
+    check-multi-line-strings: false
+  key-duplicates: enable
+  new-line-at-end-of-file: enable
+  new-lines: enable
+  trailing-spaces: enable
+  truthy:
+    level: warning

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+      - 'preview-[0-9]+\.[0-9]+\.[0-9]+'
+    paths-ignore:
+      - '.gitignore'
+      - '*.md'
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: azure/setup-helm@v3
+        with:
+          version: '3.10.0'
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.1
+        with:
+          charts_dir: 'charts/'
+        env:
+          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/sa.yml
+++ b/.github/workflows/sa.yml
@@ -39,7 +39,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+        run: ct lint --config .github/config/ct.yml --target-branch ${{ github.event.repository.default_branch }}
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/sa.yml
+++ b/.github/workflows/sa.yml
@@ -1,0 +1,54 @@
+name: static-analysis
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+      - 'preview-[0-9]+\.[0-9]+\.[0-9]+'
+    paths-ignore:
+      - '.gitignore'
+      - '*.md'
+  push:
+    branches:
+      - 'gh-actions*'
+
+jobs:
+  helm:
+    runs-on: ubuntu-latest
+    name: 'helm-sa'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
+
+      - uses: azure/setup-helm@v3
+        with:
+          version: '3.10.0'
+
+      - uses: helm/chart-testing-action@v2.3.1
+
+      - name: Run chart-testing (list-changed)
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+              echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    name: 'bash-sa (shellcheck)'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: ludeeus/action-shellcheck@1.1.0
+        with:
+          scandir: 'scripts/'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Chart dependencies
+**/charts/*.tgz
+Chart.lock
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright (c) 2022 by cisco Systems, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# XRd Helm charts
+
+This repository contains [Helm charts](https://helm.sh/) for running XRd
+using Kubernetes.
+
+There are two application charts provided in this repository:
+ - xrd-control-plane, for running XRd Control Plane containers.
+ - xrd-vrouter, for running XRd vRouter containers.
+
+There is also a library chart provided, xrd-common, that is used by both
+of the application charts.
+
+## Usage
+
+[Helm](https://helm.sh) must be installed to use the charts. Please refer to
+Helm's [documentation](https://helm.sh/docs) to get started.
+
+Once Helm has been set up correctly, add the repo as follows:
+
+```
+helm repo add <alias> https://github.com/pages/ios-xr/xrd-helm
+```
+
+If you had already added this repo earlier, run `helm repo update` to retrieve
+the latest versions of the packages.  You can then run `helm search repo
+<alias>` to see the charts.
+
+To install the <chart-name> chart:
+
+```
+helm install my-<chart-name> <alias>/<chart-name>
+```
+
+To uninstall the chart:
+
+```
+helm delete my-<chart-name>
+```

--- a/charts/xrd-common/.helmignore
+++ b/charts/xrd-common/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/xrd-common/Chart.yaml
+++ b/charts/xrd-common/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: xrd-common
+description: Common helpers for Cisco IOS-XR XRd platforms
+type: library
+keywords:
+ - cisco
+ - ios-xr
+ - xrd
+sources:
+ - https://github.com/ios-xr/xrd-helm
+version: 1.0.0-beta.1

--- a/charts/xrd-common/templates/_config-configmap.tpl
+++ b/charts/xrd-common/templates/_config-configmap.tpl
@@ -1,0 +1,40 @@
+{{- define "xrd.config-configmap" -}}
+{{- if .Values.config -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "xrd.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "xrd.commonAnnotations" . | nindent 4 }}
+  labels:
+    {{- include "xrd.commonLabels" . | nindent 4 }}
+{{- if or .Values.config.username .Values.config.ascii .Values.config.script .Values.config.ztpIni }}
+data:
+  {{- if or .Values.config.ascii .Values.config.username }}
+  startup.cfg: |
+    {{- if .Values.config.username }}
+      {{- if not .Values.config.password }}
+        {{- fail "password must be specified if username specified" }}
+      {{- end }}
+    username {{ .Values.config.username }}
+     group root-lr
+     group cisco-support
+     password {{ .Values.config.password }}
+    !
+    {{- end }}
+    {{- .Values.config.ascii | default "" | nindent 4 }}
+  {{- end }}
+  {{- if .Values.config.script }}
+  startup.sh: |
+    {{- .Values.config.script | nindent 4 }}
+  {{- end }}
+  {{- if .Values.config.ztpIni }}
+  ztp.ini: |
+    {{- .Values.config.ztpIni | nindent 4 }}
+  {{- end }}
+{{- else }}
+data: {}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/xrd-common/templates/_container-env.tpl
+++ b/charts/xrd-common/templates/_container-env.tpl
@@ -1,0 +1,70 @@
+{{- define "xrd.container-env" -}}
+{{- /*
+Generate the environment variables for XRd.
+
+This template requires a dict as the argument with the following fields:
+  - root: the root context
+  - platformEnv: a dictionary of any platform-specific environment variables.
+ */}}
+{{- $gen := dict }}
+
+{{- /* Merge the additional env vars */}}
+{{- if .platformEnv }}
+  {{- $gen = merge $gen .platformEnv }}
+{{- end }}
+
+{{- /* Generate all common env vars with the normal root context */}}
+{{- with .root }}
+  {{- /* Set the env vars version being used */}}
+  {{- $_ := set $gen "XR_ENV_VARS_VERSION" "1" }}
+
+  {{- /* Set the disk usage limit to the size of the requested PV */}}
+  {{- if .Values.persistence.enabled }}
+    {{- /*
+    Take the value, and the capitalized first letter of the size prefix so that
+    it's a valid env var value, e.g. 123kb -> 123K, 234Mi -> 234M, 345G -> 345G, etc.
+    */}}
+    {{- $size := regexFind "[0-9]+" .Values.persistence.size }}
+    {{- $suffix := .Values.persistence.size | trimPrefix $size | trunc 1 | upper }}
+    {{- $xrSize := printf "%s%s" $size $suffix }}
+    {{- $_ := set $gen "XR_DISK_USAGE_LIMIT" $xrSize }}
+  {{- end }}
+
+  {{- /* Generate config, script and ZTP env vars */}}
+  {{- with .Values.config }}
+    {{- if or .ascii .username }}
+      {{- $env := ternary "XR_EVERY_BOOT_CONFIG" "XR_FIRST_BOOT_CONFIG" (default false .asciiEveryBoot) }}
+      {{- $_ := set $gen $env "/etc/xrd/startup.cfg" }}
+    {{- end }}
+    {{- if .script }}
+      {{- $env := ternary "XR_EVERY_BOOT_SCRIPT" "XR_FIRST_BOOT_SCRIPT" (default false .scriptEveryBoot) }}
+      {{- $_ := set $gen $env "/etc/xrd/startup.sh" }}
+    {{- end }}
+    {{- if .ztpEnable }}
+      {{- $_ := set $gen "XR_ZTP_ENABLE" "1" }}
+      {{- if .ztpIni }}
+        {{- $_ := set $gen "XR_ZTP_ENABLE_WITH_INI" "/etc/xrd/ztp.ini" }}
+      {{- end }}
+    {{- else if .ztpIni }}
+      {{- fail "ztpIni can only be specified if ztpEnable is set to true" }}
+    {{- end }}
+  {{- end }}
+
+  {{- /*
+  Any explicit values in the advanced settings override values generated
+  by the sections above.
+  */}}
+  {{- $envList := list -}}
+  {{- $env := dict }}
+  {{- /* Merge has left-preference */}}
+  {{- $env := merge $env .Values.advancedSettings $gen }}
+
+  {{- range $k, $v := $env }}
+    {{- $entry := dict "name" $k "value" (toString $v) }}
+    {{- $envList = append $envList $entry }}
+  {{- end }}
+  {{- if $envList }}
+    {{- $envList | toYaml }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/xrd-common/templates/_helpers.tpl
+++ b/charts/xrd-common/templates/_helpers.tpl
@@ -1,0 +1,95 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "xrd.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "xrd.fullname" -}}
+{{- if .Values.fullnameOverride }}
+  {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+  {{- $name := default .Chart.Name .Values.nameOverride }}
+  {{- if contains $name .Release.Name }}
+    {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+  {{- else }}
+    {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "xrd.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "xrd.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "xrd.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Standard labels
+*/}}
+{{- define "xrd.labels" -}}
+helm.sh/chart: {{ include "xrd.chart" . }}
+{{ include "xrd.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Values.image.tag | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Common labels for all mutable resources
+*/}}
+{{- define "xrd.commonLabels" -}}
+{{- include "xrd.labels" . }}
+{{- /* Merge has left-precedence (i.e. things in common override things in global). */}}
+{{- $cLabels := merge .Values.commonLabels .Values.global.labels }}
+{{- if $cLabels }}
+{{ $cLabels | toYaml }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Common labels for immutable resources
+*/}}
+{{- define "xrd.commonImmutableLabels" -}}
+{{- include "xrd.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with (merge .Values.commonLabels .Values.global.labels) }}
+{{- toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Common annotations for all resources
+*/}}
+{{- define "xrd.commonAnnotations" -}}
+{{- /* Merge has left-precedence. */}}
+{{- $cAnnotations := merge .Values.commonAnnotations .Values.global.annotations }}
+{{- if $cAnnotations }}
+{{- $cAnnotations | toYaml }}
+{{- end }}
+{{- end -}}
+
+{{- /* Misc helpers */ -}}
+{{- define "xrd.toMiB" -}}
+{{- /*
+Convert a k8s resource specification of Mi or Gi into MiB for XR env vars.
+*/ -}}
+{{- if hasSuffix "Mi" . -}}
+{{ trimSuffix "Mi" . }}
+{{- else if hasSuffix "Gi" . -}}
+{{ . | trimSuffix "Gi" | trim | int | mul 1024 | toString }}
+{{- end -}}
+{{- end -}}

--- a/charts/xrd-common/templates/_network-attachments.tpl
+++ b/charts/xrd-common/templates/_network-attachments.tpl
@@ -1,0 +1,25 @@
+{{- define "xrd.network-attachments" -}}
+{{- range $idx, $intf := concat .Values.interfaces .Values.mgmtInterfaces }}
+{{- if eq $intf.type "multus" }}
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: {{ include "xrd.fullname" $ }}-{{ $idx }}
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    {{- include "xrd.commonAnnotations" $ | nindent 4 }}
+  labels:
+    {{- include "xrd.commonLabels" $ | nindent 4 }}
+spec:
+  config: |-
+    {
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {{- $intf.config | toPrettyJson | nindent 8 }}
+      ]
+    }
+...
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/xrd-common/templates/_statefulset.tpl
+++ b/charts/xrd-common/templates/_statefulset.tpl
@@ -1,0 +1,182 @@
+{{- define "xrd.statefulset" -}}
+{{- /*
+Generate the statefulset for XRd.
+
+This template requires a dict as the argument with the following fields:
+  - root: the root context.
+  - environment: a dictionary of any platform-specific environment variables.
+  - resources: a dict containing container resource settings.
+ */}}
+{{- $root := .root }}
+{{- $resources := .resources }}
+{{- $platformEnv := .environment }}
+{{- with .root }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "xrd.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "xrd.commonAnnotations" . | nindent 4 }}
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "xrd.commonLabels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: 1
+  serviceName: {{ include "xrd.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "xrd.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- include "xrd.commonAnnotations" . | nindent 8 }}
+        {{- if (include "xrd.interfaces.anyMultus" .) }}
+        k8s.v1.cni.cncf.io/networks: |-
+          {{- include "xrd.podNetworkAnnotations" . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "xrd.commonLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
+      volumes:
+      {{- if .Values.config }}
+      - name: config
+        configMap:
+          name: {{ include "xrd.fullname" . }}-config
+          items:
+            {{- if or .Values.config.username .Values.config.ascii }}
+            - key: startup.cfg
+              path: startup.cfg
+            {{- end }}
+            {{- if .Values.config.script }}
+            - key: startup.sh
+              path: startup.sh
+              mode: 0744
+            {{- end }}
+            {{- if .Values.config.ztpIni }}
+            - key: ztp.ini
+              path: ztp.ini
+            {{- end }}
+      {{- end }}
+      {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
+      - name: xr-storage
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim | quote }}
+      {{- end }}
+      {{- range .Values.extraHostPathMounts }}
+      - name: {{ include "xrd.fullname" $root }}-hostmount-{{ .name }}
+        hostPath:
+          path: {{ .hostPath | quote }}
+          {{- if .create }}
+          type: DirectoryOrCreate
+          {{- else }}
+          type: Directory
+          {{- end }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+      {{- toYaml .Values.extraVolumes | nindent 6 }}
+      {{- end }}
+      containers:
+      {{- $repo := required "Image repository must be specified" .Values.image.repository }}
+      {{- $tag := required "Image tag must be specified" .Values.image.tag }}
+      - image: {{ printf "\"%s:%s\"" $repo $tag }}
+        {{- if $resources }}
+        resources:
+          {{- $resources | toYaml | nindent 10 }}
+        {{- end }}
+        name: main
+        securityContext:
+        {{- toYaml .Values.securityContext | nindent 10 }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        tty: true
+        stdin: true
+        env:
+          {{- $envArgs := dict "root" . "platformEnv" $platformEnv }}
+          {{- include "xrd.container-env" $envArgs | nindent 8 }}
+        volumeMounts:
+        {{- if .Values.config }}
+        - mountPath: /etc/xrd
+          name: config
+          readOnly: true
+        {{- end }}
+        {{- if .Values.persistence.enabled }}
+        - mountPath: /xr-storage
+          name: xr-storage
+        {{- end }}
+        {{- range .Values.extraHostPathMounts }}
+        - mountPath: {{ .mountPath | default .hostPath }}
+          name: {{include "xrd.fullname" $root }}-hostmount-{{ .name }}
+        {{- end }}
+        {{- if .Values.extraVolumeMounts }}
+        {{- toYaml .Values.extraVolumeMounts | nindent 8 }}
+        {{- end }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSpecExtra }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  {{- with .Values.persistence }}
+  {{- if and .enabled (not .existingClaim) }}
+  volumeClaimTemplates:
+  - metadata:
+      name: xr-storage
+      annotations:
+        {{- include "xrd.commonAnnotations" $root | nindent 8 }}
+        {{- if .annotations }}
+        {{- .annotations | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "xrd.commonImmutableLabels" $root | nindent 8 }}
+    spec:
+      accessModes:
+      {{- .accessModes | toYaml | nindent 6 }}
+      {{- if .selector }}
+      selector:
+        {{- .selector | toYaml | nindent 8 }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .size | quote }}
+      {{- if .existingVolume }}
+      volumeName: {{ .existingVolume | quote }}
+      {{- end }}
+      {{- /* N.B. Missing SC definition is different to empty string definition! */}}
+      {{- if hasKey . "storageClass" }}
+      storageClassName: {{ .storageClass | quote }}
+      {{- end }}
+      {{- if .dataSource }}
+      dataSource:
+        {{- .dataSource | nindent 8 }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/xrd-control-plane/.helmignore
+++ b/charts/xrd-control-plane/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/xrd-control-plane/Chart.yaml
+++ b/charts/xrd-control-plane/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: xrd-control-plane
+description: Cisco IOS-XR XRd Control Plane platform
+type: application
+keywords:
+- cisco
+- ios-xr
+- xrd
+sources:
+- https://github.com/ios-xr/xrd-helm
+version: 1.0.0-beta.1
+dependencies:
+- name: xrd-common
+  version: 1.0.0-beta.1
+  repository: "file://../xrd-common"

--- a/charts/xrd-control-plane/ci/example-values.yaml
+++ b/charts/xrd-control-plane/ci/example-values.yaml
@@ -1,0 +1,3 @@
+image:
+  repository: required
+  tag: latest

--- a/charts/xrd-control-plane/templates/NOTES.txt
+++ b/charts/xrd-control-plane/templates/NOTES.txt
@@ -1,0 +1,1 @@
+You have installed XRd Control Plane version {{ .Values.tag }}.

--- a/charts/xrd-control-plane/templates/_interfaces.tpl
+++ b/charts/xrd-control-plane/templates/_interfaces.tpl
@@ -1,0 +1,60 @@
+{{- define "xrd-cp.interfaces" -}}
+{{- /* Generate the XR_INTERFACES environment variable content */ -}}
+{{- $interfaces := list }}
+{{- $hasPci := 0 }}
+{{- $hasPciRange := 0 }}
+{{- $cniIndex := 0 }}
+{{- include "xrd.interfaces.checkDefaultCniCount" . -}}
+{{- range .Values.interfaces }}
+  {{- if eq .type "defaultCni" }}
+    {{- if hasKey . "attachmentConfig" }}
+      {{- fail "attachmentConfig may not be specified for defaultCni interfaces" }}
+    {{- end }}
+    {{- $flags := include "xrd.interfaces.linuxflags" . }}
+    {{- if $flags }}
+      {{- $interfaces = append $interfaces (printf "linux:eth0,%s" $flags) }}
+    {{- else }}
+      {{- $interfaces = append $interfaces "linux:eth0" }}
+    {{- end }}
+  {{- else if eq .type "multus" }}
+    {{- $cniIndex = add1 $cniIndex }}
+    {{- $flags := include "xrd.interfaces.linuxflags" . }}
+    {{- if $flags }}
+      {{- $interfaces = append $interfaces (printf "linux:net%d,%s" $cniIndex $flags) }}
+    {{- else }}
+      {{- $interfaces = append $interfaces (printf "linux:net%d" $cniIndex) }}
+    {{- end }}
+  {{- else }}
+    {{- fail (printf "Invalid interface type %s" .type) }}
+  {{- end }}
+{{- end }}
+{{- join ";" $interfaces }}
+{{- end -}}
+
+{{- define "xrd-cp.mgmtInterfaces" -}}
+{{- /* Generate the XR_MGMT_INTERFACES environment variable content */ -}}
+{{- $interfaces := list }}
+{{- $cniIndex := atoi (include "xrd.interfaces.multusCount" .Values.interfaces) }}
+{{- include "xrd.interfaces.checkDefaultCniCount" . -}}
+{{- range .Values.mgmtInterfaces }}
+  {{- if eq .type "defaultCni" }}
+    {{- $flags := include "xrd.interfaces.linuxflags" . }}
+    {{- if $flags }}
+      {{- $interfaces = append $interfaces (printf "linux:eth0,%s" $flags) }}
+    {{- else }}
+      {{- $interfaces = append $interfaces "linux:eth0" }}
+    {{- end }}
+  {{- else if eq .type "multus" }}
+    {{- $cniIndex = add1 $cniIndex }}
+    {{- $flags := include "xrd.interfaces.linuxflags" . }}
+    {{- if $flags }}
+      {{- $interfaces = append $interfaces (printf "linux:net%d,%s" $cniIndex $flags) }}
+    {{- else }}
+      {{- $interfaces = append $interfaces (printf "linux:net%d" $cniIndex) }}
+    {{- end }}
+  {{- else }}
+    {{- fail (printf "Invalid mgmt interface type %s" .type) }}
+  {{- end }}
+{{- end }}
+{{- join ";" $interfaces }}
+{{- end -}}

--- a/charts/xrd-control-plane/templates/config-configmap.yaml
+++ b/charts/xrd-control-plane/templates/config-configmap.yaml
@@ -1,0 +1,1 @@
+{{- include "xrd.config-configmap" . -}}

--- a/charts/xrd-control-plane/templates/network-attachments.yaml
+++ b/charts/xrd-control-plane/templates/network-attachments.yaml
@@ -1,0 +1,1 @@
+{{ include "xrd.network-attachments" . }}

--- a/charts/xrd-control-plane/templates/statefulset.yaml
+++ b/charts/xrd-control-plane/templates/statefulset.yaml
@@ -1,0 +1,41 @@
+{{- /*
+Set up the arguments for the common statefulset template and then invoke it.
+*/}}
+
+{{- /*
+Firstly, generate the resources for the XRd container, including any
+defaults if not overridden.
+XRd Control Plane has a default memory request of 2Gi.
+*/}}
+{{- $default := dict }}
+{{- $hasMemory := false }}
+{{- range $_, $settings := .Values.resources }}
+  {{- range $k := keys $settings }}
+    {{- if eq $k "memory" }}
+      {{- $hasMemory = true }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- $defaultLimits := dict }}
+{{- $defaultRequests := dict }}
+{{- if not $hasMemory }}
+  {{- $_ := set $defaultRequests "memory" "2Gi" }}
+{{- end }}
+{{- $_ := set $default "limits" $defaultLimits }}
+{{- $_ := set $default "requests" $defaultRequests }}
+
+{{- /* Generate the merged resources for the container */}}
+{{- $resources := dict }}
+{{- $resources = merge $resources .Values.resources $default }}
+
+{{- /*
+Set up the platform-specific environment variables.
+For XRd Control Plane this is only the interface specification.
+*/}}
+{{- $interfaces := include "xrd-cp.interfaces" . }}
+{{- $mgmtInterfaces := include "xrd-cp.mgmtInterfaces" . }}
+{{- $env := dict "XR_INTERFACES" $interfaces "XR_MGMT_INTERFACES" $mgmtInterfaces }}
+
+{{- /* Create the args dict and invoke the generic template. */}}
+{{- $args := dict "root" $ "resources" $resources "environment" $env }}
+{{- include "xrd.statefulset" $args -}}

--- a/charts/xrd-control-plane/values.schema.json
+++ b/charts/xrd-control-plane/values.schema.json
@@ -1,0 +1,375 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "http://cisco.com/xrd/helm",
+  "title": "XRd Helm Chart Values",
+  "description": "Configuration values for XRd helm charts",
+  "type": "object",
+  "properties": {
+    "global": {
+      "description": "Global settings used by XRd definitions",
+      "type": "object",
+      "properties": {
+        "labels": {
+          "description": "Labels added to every resource",
+          "type": "object"
+        },
+        "annotations": {
+          "description": "Annotations added to every resource",
+          "type": "object"
+        }
+      }
+    },
+    "nameOverride": {
+      "description": "Override the basename used when naming generated resources",
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "description": "Override the full name used when naming generated resources",
+      "type": "string"
+    },
+    "image": {
+      "description": "Container image config",
+      "type": "object",
+      "properties": {
+        "repository": {
+          "description": "Repository to pull the image from (required)",
+          "type": "string"
+        },
+        "tag": {
+          "description": "Image tag to pull from the repository (required)",
+          "type": "string"
+        },
+        "pullPolicy": {
+          "description": "Standard Kubernetes image pull policy",
+          "type": "string",
+          "default": "Always",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
+        },
+        "pullSecrets": {
+          "description": "Standard Kuberenetes pod imagePullSecrets array",
+          "type": "array"
+        }
+      },
+      "required": [
+        "repository",
+        "tag"
+      ],
+      "additionalProperties": false
+    },
+    "commonLabels": {
+      "description": "Labels added to every resource",
+      "type": "object"
+    },
+    "commonAnnotations": {
+      "description": "Annotations added to every resource",
+      "type": "object"
+    },
+    "labels": {
+      "description": "Labels added to the XRd deployment",
+      "type": "object"
+    },
+    "annotations": {
+      "description": "Annotations added to the XRd deployment",
+      "type": "object"
+    },
+    "resources": {
+      "description": "Standard Kubernetes container resources object",
+      "type": "object"
+    },
+    "securityContext": {
+      "description": "Standard Kubernetes container securityContext object",
+      "type": "object"
+    },
+    "hostNetwork": {
+      "description": "Flag indicating whether or not to use the host's network namespace",
+      "type": "boolean",
+      "default": false
+    },
+    "nodeSelector": {
+      "description": "Standard Kubernetes pod nodeSelector object",
+      "type": "object"
+    },
+    "tolerations": {
+      "description": "Standard Kubernetes pod tolerations array",
+      "type": "array"
+    },
+    "affinity": {
+      "description": "Standard Kubernetes pod affinity object",
+      "type": "object"
+    },
+    "podLabels": {
+      "description": "Labels added to the XRd pod",
+      "type": "object"
+    },
+    "podAnnotations": {
+      "description": "Annotations added to the XRd pod",
+      "type": "object"
+    },
+    "config": {
+      "description": "XRd configuration",
+      "type": "object",
+      "properties": {
+        "username": {
+          "description": "Username of a root user to add to the XR configuration",
+          "type": "string"
+        },
+        "password": {
+          "description": "Password for the root user (plaintext). Must be set if username is set",
+          "type": "string"
+        },
+        "ascii": {
+          "description": "ASCII XR configuration",
+          "type": "string"
+        },
+        "asciiEveryBoot": {
+          "description": "Flag indicating if the ASCII configuration should be applied on every boot (true), or just first boot (false)",
+          "type": "boolean",
+          "default": false
+        },
+        "script": {
+          "description": "XR boot script contents",
+          "type": "string"
+        },
+        "scriptEveryBoot": {
+          "description": "Flag indicating if the boot script should be run on every boot (true), or just first boot (false)",
+          "type": "boolean",
+          "default": false
+        },
+        "ztpEnable": {
+          "description": "Flag indicating if ZTP should be enabled",
+          "type": "boolean"
+        },
+        "ztpIni": {
+          "description": "Contents of a custom ZTP ini file to use. May only be set when ztpEnable is specified",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "persistence": {
+      "description": "Persistent storage settings",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable persistent storage",
+          "type": "boolean",
+          "default": true
+        },
+        "size": {
+          "description": "Size of the persistent storage volume",
+          "type": "string",
+          "default": "6Gi"
+        },
+        "accessModes": {
+          "description": "Persistent Volume access modes",
+          "type": "array",
+          "item": {
+            "type": "string"
+          }
+        },
+        "storageClass": {
+          "description": "Storage class for the persistent volume",
+          "type": "string"
+        },
+        "existingVolume": {
+          "description": "Use an existing Persistent Volume which must be created manually",
+          "type": "string"
+        },
+        "annotations": {
+          "description": "Annotations added to the PVC",
+          "type": "object"
+        },
+        "selector": {
+          "description": "Selector label query for the PVC",
+          "type": "object"
+        },
+        "dataSource": {
+          "description": "Custom PVC data source",
+          "type": "object"
+        },
+        "existingClaim": {
+          "description": "Use an existing Persistent Volume Claim which must be created manually",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "extraVolumes": {
+      "description": "Extra volumes for the XRd pod",
+      "type": "array",
+      "item": {
+        "type": "object"
+      }
+    },
+    "extraVolumeMounts": {
+      "description": "Extra volume mounts for the XRd container",
+      "type": "array",
+      "item": {
+        "type": "object"
+      }
+    },
+    "extraHostPathMounts": {
+      "description": "Extra hostpath mounts for the XRd container",
+      "type": "array",
+      "item": {
+        "description": "Information for a single host mount",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Unique name for the host mount",
+            "type": "string"
+          },
+          "hostPath": {
+            "description": "Path on the host to mount in the container",
+            "type": "string"
+          },
+          "mountPath": {
+            "description": "Path in the container mount the host directory",
+            "type": "string"
+          },
+          "create": {
+            "description": "Flag indicating whether or not to create the directory if it's missing on the host",
+            "type": "boolean",
+            "default": false
+          }
+        },
+        "required": [
+          "hostPath"
+        ]
+      }
+    },
+    "interfaces": {
+      "description": "Line interface settings",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "Underying interface type. One of: 'defaultCni' or 'multus'",
+            "type": "string",
+            "enum": [
+              "defaultCni",
+              "multus"
+            ]
+          },
+          "config": {
+            "description": "Type-dependent configuration",
+            "type": "object"
+          },
+          "attachmentConfig": {
+            "description": "Network attachment annotation configuration, for multus-type interfaces only",
+            "type": "object"
+          },
+          "snoopIpv4Address": {
+            "description": "Indicate whether to snoop the pre-existing IPv4 address of the interface into XR config",
+            "type": "boolean",
+            "default": false
+          },
+          "snoopIpv4DefaultRoute": {
+            "description": "Indicate whether snoop the pre-existing IPv4 default route of the interface into XR config",
+            "type": "boolean",
+            "default": false
+          },
+          "snoopIpv6Address": {
+            "description": "Flag indicating whether to snoop the pre-existing IPv6 address of the interface into XR config",
+            "type": "boolean",
+            "default": false
+          },
+          "snoopIpv6DefaultRoute": {
+            "description": "Flag indicating whether to snoop the pre-existing IPv6 default route of the interface into XR config",
+            "type": "boolean",
+            "default": false
+          },
+          "chksum": {
+            "description": "Flag indicating whether TCP/UDP checksums must be calculated for XRd for ingress packets to counteract checksum offload",
+            "type": "boolean",
+            "default": false
+          },
+          "xrName": {
+            "description": "Customize the XR interface name for this interface",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "mgmtInterfaces": {
+      "description": "Management interface settings",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "Underying interface type. One of: 'defaultCni' or 'multus'",
+            "type": "string",
+            "enum": [
+              "defaultCni",
+              "multus"
+            ]
+          },
+          "config": {
+            "description": "Type-dependent configuration",
+            "type": "object"
+          },
+          "attachmentConfig": {
+            "description": "Network attachment annotation configuration, for multus-type interfaces only",
+            "type": "object"
+          },
+          "snoopIpv4Address": {
+            "description": "Indicate whether to snoop the pre-existing IPv4 address of the interface into XR config",
+            "type": "boolean",
+            "default": false
+          },
+          "snoopIpv4DefaultRoute": {
+            "description": "Indicate whether snoop the pre-existing IPv4 default route of the interface into XR config",
+            "type": "boolean",
+            "default": false
+          },
+          "snoopIpv6Address": {
+            "description": "Flag indicating whether to snoop the pre-existing IPv6 address of the interface into XR config",
+            "type": "boolean",
+            "default": false
+          },
+          "snoopIpv6DefaultRoute": {
+            "description": "Flag indicating whether to snoop the pre-existing IPv6 default route of the interface into XR config",
+            "type": "boolean",
+            "default": false
+          },
+          "chksum": {
+            "description": "Flag indicating whether TCP/UDP checksums must be calculated for XRd for ingress packets to counteract checksum offload",
+            "type": "boolean",
+            "default": false
+          },
+          "xrName": {
+            "description": "Customize the XR interface name for this interface",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "advancedSettings": {
+      "description": "Advanced settings for XRd not required for normal deployments",
+      "$comment": "XRd environment variables copied verbatim into the container environment",
+      "type": "object"
+    },
+    "xrd-common": {
+      "description": "Dummy placeholder for xrd-common subchart settings (never used)",
+      "type": "object"
+    }
+  },
+  "required": [
+    "image"
+  ],
+  "additionalProperties": false
+}

--- a/charts/xrd-control-plane/values.yaml
+++ b/charts/xrd-control-plane/values.yaml
@@ -1,0 +1,226 @@
+# Default values for XRd Control Plane.
+#
+# There are two required fields which have no defaults and must
+# be specified for all installations:
+# - image.repository
+# - image.tag
+
+# Image configuration
+image:
+  # Repository for the container image (required).
+  #repository: ""
+  # Image tag (required).
+  #tag: ""
+  # Pull policy for images.
+  # One of "IfNotPresent", "Always", or "Never"
+  # See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+  pullPolicy: Always
+  # Image pull secrets.
+  # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  pullSecrets: []
+
+# Override the basename used for generated resources.
+#nameOverride: ""
+
+# Override the name used for generated resources.
+#fullnameOverride: ""
+
+# Global configuration
+global:
+  # Labels to add to all deployed objects.
+  labels: {}
+
+  # Annotations to add to all deployed objects.
+  annotations: {}
+
+# Labels to add to all deployed objects.
+commonLabels: {}
+
+# Annotations to add to all deployed objects.
+commonAnnotations: {}
+
+# Labels added to the XRd deployment.
+labels: {}
+
+# Annotations added to the XRd deployment.
+annotations: {}
+
+# Pod resource configuration.
+# See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+# The default resources are:
+#   - 2Gi memory request (unless a memory request/limit is specified here).
+resources: {}
+# Example default resources for XRd Control Plane:
+#  requests:
+#    memory: 2Gi
+
+# Security context for the XRd container.
+# Privileged mode is currently required for XRd in K8s due to device
+# access requirements.
+securityContext:
+  privileged: true
+
+# Use the host network namespace.
+hostNetwork: false
+
+# Location control for the XRd pod.
+# Standard K8s configuration, more information available at:
+# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+# Node labels for pod assignment.
+nodeSelector: {}
+# List of node taints to tolerate.
+tolerations: []
+# Affinity for pod assignment.
+affinity: {}
+
+# Labels added to the XRd pod.
+podLabels: {}
+
+# Annotations added to the XRd pod.
+podAnnotations: {}
+
+# Persistent storage controls.
+persistence:
+  # Enable persistent storage.
+  enabled: false
+  # Persistent Volume size.
+  size: "6Gi"
+  # Persistent volume access modes.
+  accessModes:
+  - ReadWriteOnce
+  # Storage class for the persistent volume.
+  # This storage class must be defined separately.
+  # N.B Not specifying a storage class is not the same as specifying an
+  # empty string! (https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+  #storageClass: ""
+  # Bind to an existing Persistent Volume.
+  # If specified this must be a pre-existing PV that is not bound.
+  #existingVolume: ""
+  # Annotations added to the PVC.
+  annotations: {}
+  # Selector for the PVC.
+  #selector: {}
+  # Custom PVC data source.
+  #dataSource: {}
+  # Use an existing bound Persistent Volume Claim.
+  # If specified this must be a pre-existing PVC that is bound.
+  # This overrides any other settings in this section.
+  #existingClaim: ""
+
+# Extra volume definitions for the XRd pod.
+# These are added verbatim to the XRd pod volumes.
+extraVolumes: []
+
+# Extra volume mounts for the XRd container.
+# These are added verbatim to the XRd container volume mounts.
+extraVolumeMounts: []
+
+# Extra host path mounts for the XRd container.
+# This can be used to mount additional host paths into the container instead
+# of defining an extraVolumes entry and an extraVolumeMounts entry.
+extraHostPathMounts: []
+  # Unique name (required)
+  #- name: ""
+  # Path from the host to mount in the container (required)
+  #hostPath: ""
+  # Path to use as the mount point in the container (defaults to the same
+  # as the hostPath).
+  #mountPath: ""
+  # Flag indicating whether or not to create the directory if it doesn't
+  # exist at container start (default false).
+  #create: false
+
+# XR configuration and boot scripts.
+config:
+  # Username and password for the root system user.
+  # This field can be used instead of putting the user configuration in
+  # the ascii configuration below so values files can be distributed
+  # without username and password data.
+  # This MUST NOT clash with the ASCII config below!
+  # These must be specified together, i.e. both or neither must be specified.
+  #username: ""
+  #password: ""
+  # ASCII XR configuration to be applied on XR boot.
+  #ascii: ""
+  # Flag indicating when the above configuration should be applied:
+  #  - false indicates only on first boot.
+  #  - true indicates on every boot.
+  # Defaults to false (only first boot).
+  #asciiEveryBoot: false
+  # Contents of a script to run on XR boot.
+  #script: ""
+  # Flag indicating when the above script should be run:
+  #  - false indicates only on first boot.
+  #  - true indicates on every boot.
+  # Defaults to false (only first boot).
+  #scriptEveryBoot: false
+  # ZTP enable flag.
+  ztpEnable: false
+  # Contents of a custom ZTP ini file to use.
+  # This may only be set when the ztpEnable flag is set to 'true'
+  #ztpIni: ""
+
+# XRd interfaces.
+# These are split into two arrays:
+#  - An array of line interfaces: 'interfaces'
+#  - An array of management interfaces: 'mgmtInterfaces'
+#
+# Each of these is an array of interface objects.
+# Interfaces can be one of the following types:
+#  - defaultCni: This interface connects to the defaultCNI veth interface
+#                created in each pod.
+#                Only one interface of this type may be specified (across both
+#                interfaces and mgmtInterfaces).
+#  - multus:     This connects to an interface created using a CNI plugin,
+#                driven by the multus meta-CNI plugin.
+#                All of the network attachment definition configuration must be
+#                specified under the 'config' field for the interface.
+#                Any attachment annotation configuration may be specified under
+#                the 'attachmentConfig' field.
+#
+# On 'defaultCni' and 'multus' interfaces, the following options may also
+# be specified to control the interface behavior in XR:
+#   - chksum: Turn on TCP/UDP checksum calculation for ingress packets (to
+#             counteract checksum offload to hardware).
+#   - xrName: Customize the XR interface name for this interface.
+#   - snoopIpv4Address: see below.
+#   - snoopIpv4DefaultRoute: see below.
+#   - snoopIpv6Address: see below.
+#   - snoopIpv6Address: see below.
+# The snooping options find the named configuration item in the
+# container network namespace and apply that configuration into XR, e.g.
+# if snoopIpv4Address is specified, the IPv4 address for the underlying
+# linux interface is found, and XR configuration for that IPv4 address
+# on the corresponding XR interface is generated and applied on XRd startup.
+#
+# XRd line interfaces.
+interfaces: []
+# Example interfaces:
+#- type: multus
+#  config:
+#    type: host-device
+#    device: eth1
+#  xrName: GigabitEthernet0/0/0/3
+
+# XRd management interfaces.
+mgmtInterfaces: []
+# Example interfaces:
+#- type: defaultCni
+#  snoopIpv4Address: true
+#  snoopIpv4DefaultRoute: true
+#  chksum: true
+#- type: multus
+#  config:
+#    type: macvlan
+#    master: eth1
+#    mode: bridge
+#    ipam:
+#      type: static
+#  attachmentConfig:
+#    ips:
+#    - "10.0.0.1/24"
+
+# XRd advanced settings.
+# This section contains settings not required by most users.
+# Details can be found here: @@@
+advancedSettings: {}

--- a/charts/xrd-vrouter/.helmignore
+++ b/charts/xrd-vrouter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/xrd-vrouter/Chart.yaml
+++ b/charts/xrd-vrouter/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: xrd-vrouter
+description: Cisco IOS-XR XRd vRouter platform
+type: application
+keywords:
+ - cisco
+ - ios-xr
+ - xrd
+sources:
+ - https://github.com/ios-xr/xrd-helm
+version: 1.0.0-beta.1
+dependencies:
+- name: xrd-common
+  version: 1.0.0-beta.1
+  repository: "file://../xrd-common"

--- a/charts/xrd-vrouter/ci/example-values.yaml
+++ b/charts/xrd-vrouter/ci/example-values.yaml
@@ -1,0 +1,3 @@
+image:
+  repository: required
+  tag: latest

--- a/charts/xrd-vrouter/templates/NOTES.txt
+++ b/charts/xrd-vrouter/templates/NOTES.txt
@@ -1,0 +1,1 @@
+You have installed XRd vRouter version {{ .Values.tag }}.

--- a/charts/xrd-vrouter/templates/_interfaces.tpl
+++ b/charts/xrd-vrouter/templates/_interfaces.tpl
@@ -1,0 +1,91 @@
+{{- define "xrd-vr.interfaces" -}}
+{{- /* Generate the XR_INTERFACES environment variable content */ -}}
+{{- $interfaces := list }}
+{{- $hasPci := 0 }}
+{{- $hasPciRange := 0 }}
+{{- $cniIndex := 0 }}
+{{- include "xrd.interfaces.checkDefaultCniCount" . -}}
+{{- range .Values.interfaces }}
+  {{- if eq .type "pci" }}
+    {{- if hasKey . "attachmentConfig" }}
+      {{- fail "attachmentConfig may not be specified for PCI interfaces" }}
+    {{- end }}
+    {{- $flags := include "xrd.interfaces.pciflags" . }}
+    {{- if $hasPciRange }}
+      {{- fail "If a pci interface range (i.e. with 'first' or 'last' config) is specified, no other pci interfaces may be specified" }}
+    {{- end }}
+    {{- if hasKey .config "device" }}
+      {{- if or (hasKey .config "first") (hasKey .config "last") }}
+        {{- fail "Cannot specify 'device' and either 'first' or 'last' for PCI interfaces" }}
+      {{- end }}
+      {{- $hasPci = 1 }}
+      {{- if $flags }}
+        {{- $interfaces = append $interfaces (printf "pci:%s,%s" .config.device $flags) }}
+      {{- else }}
+        {{- $interfaces = append $interfaces (printf "pci:%s" .config.device) }}
+      {{- end }}
+    {{- else if or (hasKey .config "first") (hasKey .config "last") }}
+      {{- if and (hasKey .config "first") (hasKey .config "last") }}
+        {{- fail "Cannot specify both 'first' and 'last' for PCI interface" }}
+      {{- end }}
+      {{- $hasPciRange = 1 }}
+      {{- if $hasPci }}
+        {{- fail "If a pci interface range (i.e. with 'first' or 'last' config) is specified, no other pci interfaces may be specified" }}
+      {{- end }}
+      {{- $config := "" }}
+      {{- if .config.last }}
+        {{- $config = printf "last%v" .config.last }}
+      {{- else if .config.first }}
+        {{- $config = printf "last%v" .config.first }}
+      {{- end }}
+      {{- if $flags }}
+        {{- $interfaces = append $interfaces (printf "pci-range:%s,%s" $config $flags) }}
+      {{- else }}
+        {{- $interfaces = append $interfaces (printf "pci-range:%s" $config) }}
+      {{- end }}
+    {{- else }}
+      {{- fail "Must specify one of 'device', 'first', or 'last' for PCI interfaces" }}
+    {{- end }}
+  {{- else }}
+    {{- fail (printf "Invalid interface type %s" .type) }}
+  {{- end }}
+{{- end }}
+{{- join ";" $interfaces }}
+{{- end -}}
+
+{{- define "xrd-vr.mgmtInterfaces" -}}
+{{- /* Generate the XR_MGMT_INTERFACES environment variable content */ -}}
+{{- $interfaces := list }}
+{{- $cniIndex := atoi (include "xrd.interfaces.multusCount" .Values.interfaces) }}
+{{- if gt (len .Values.mgmtInterfaces) 1 }}
+  {{- fail "Only one management interface can be specified on XRd vRouter" }}
+{{- end }}
+{{- include "xrd.interfaces.checkDefaultCniCount" . -}}
+{{- range .Values.mgmtInterfaces }}
+  {{- if eq .type "defaultCni" }}
+    {{- if (hasKey . "xrName") }}
+      {{- fail "xrName may not be specified for interfaces on XRd vRouter" }}
+    {{- end }}
+    {{- $flags := include "xrd.interfaces.linuxflags" . }}
+    {{- if $flags }}
+      {{- $interfaces = append $interfaces (printf "linux:eth0,%s" $flags) }}
+    {{- else }}
+      {{- $interfaces = append $interfaces "linux:eth0" }}
+    {{- end }}
+  {{- else if eq .type "multus" }}
+    {{- $cniIndex = add1 $cniIndex }}
+    {{- if (hasKey . "xrName") }}
+      {{- fail "xrName may not be specified for interfaces on XRd vRouter" }}
+    {{- end }}
+    {{- $flags := include "xrd.interfaces.linuxflags" . }}
+    {{- if $flags }}
+      {{- $interfaces = append $interfaces (printf "linux:net%d,%s" $cniIndex $flags) }}
+    {{- else }}
+      {{- $interfaces = append $interfaces (printf "linux:net%d" $cniIndex) }}
+    {{- end }}
+  {{- else }}
+    {{- fail (printf "Invalid mgmt interface type %s" .type) }}
+  {{- end }}
+{{- end }}
+{{- join ";" $interfaces }}
+{{- end -}}

--- a/charts/xrd-vrouter/templates/config-configmap.yaml
+++ b/charts/xrd-vrouter/templates/config-configmap.yaml
@@ -1,0 +1,1 @@
+{{ include "xrd.config-configmap" . }}

--- a/charts/xrd-vrouter/templates/network-attachments.yaml
+++ b/charts/xrd-vrouter/templates/network-attachments.yaml
@@ -1,0 +1,1 @@
+{{ include "xrd.network-attachments" . }}

--- a/charts/xrd-vrouter/templates/statefulset.yaml
+++ b/charts/xrd-vrouter/templates/statefulset.yaml
@@ -1,0 +1,80 @@
+{{- /*
+Set up the arguments for the common statefulset template and then invoke it.
+*/}}
+
+{{- /*
+Firstly, generate the resources for the XRd container, including any
+defaults if not overridden.
+XRd vRouter has a default memory request of 5Gi memory, and a default
+hugepages-1Gi limit (and implicit request) of 3Gi.
+Store any found or generated hugepage size for the env vars later on.
+*/}}
+{{- $default := dict }}
+
+{{- /* Check if any hugepage or memory configuration is specified. */}}
+{{- $hasHugepage := false }}
+{{- $hasMemory := false }}
+{{- $hugepageSize := "" }}
+{{- range $_, $settings := .Values.resources }}
+  {{- range $k := keys $settings }}
+    {{- if hasPrefix "hugepages" $k }}
+      {{- $hasHugepage = true }}
+      {{- $hugepageSize = get $settings $k }}
+    {{- end }}
+    {{- if eq $k "memory" }}
+      {{- $hasMemory = true }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- /*
+Construct the resources including the default if that resource wasn't specified.
+*/}}
+{{- $defaultLimits := dict }}
+{{- $defaultRequests := dict }}
+{{- if not $hasHugepage }}
+  {{- $_ := set $defaultLimits "hugepages-1Gi" "3Gi" }}
+  {{- $hugepageSize = "3Gi" }}
+{{- end }}
+{{- if not $hasMemory }}
+  {{- $_ := set $defaultRequests "memory" "5Gi" }}
+{{- end }}
+{{- $_ := set $default "limits" $defaultLimits }}
+{{- $_ := set $default "requests" $defaultRequests }}
+
+{{- /* Generate the merged resources for the container */}}
+{{- $resources := dict }}
+{{- $resources = merge $resources .Values.resources $default }}
+
+{{- /* Set up the platform-specific environment variables. */}}
+{{- $env := dict }}
+
+{{- /* Set the hugepage limit based on the resources */}}
+{{- $hugepageMb := include "xrd.toMiB" $hugepageSize }}
+{{- $_ := set $env "XR_VROUTER_DP_HUGEPAGE_MB" $hugepageMb  }}
+
+{{- /* Generate CPU env vars */}}
+{{- if .Values.cpu }}
+  {{- with .Values.cpu.cpuset }}
+    {{- $_ := set $env "XR_VROUTER_CPUSET" . }}
+  {{- end }}
+  {{- with .Values.cpu.controlPlaneCpuCount }}
+    {{- $_ := set $env "XR_VROUTER_CP_NUM_CPUS" . }}
+  {{- end }}
+  {{- with .Values.cpu.hyperThreadingMode }}
+    {{- $_ := set $env "XR_VROUTER_HT_MODE" . }}
+  {{- end }}
+{{- end }}
+
+{{- /* Generate the PCI driver env var */}}
+{{- if .Values.pciDriver }}
+  {{- $_ := set $env "XR_VROUTER_PCI_DRIVER" .Values.pciDriver }}
+{{- end }}
+
+{{- /* Generate the interface env vars */}}
+{{- $_ = set $env "XR_INTERFACES" (include "xrd-vr.interfaces" .) }}
+{{- $_ = set $env "XR_MGMT_INTERFACES" (include "xrd-vr.mgmtInterfaces" .) }}
+
+{{- /* Create the args dict and invoke the generic template. */}}
+{{- $args := dict "root" $ "resources" $resources "environment" $env }}
+{{- include "xrd.statefulset" $args -}}

--- a/charts/xrd-vrouter/values.schema.json
+++ b/charts/xrd-vrouter/values.schema.json
@@ -1,0 +1,373 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "http://cisco.com/xrd/helm",
+  "title": "XRd Helm Chart Values",
+  "description": "Configuration values for XRd helm charts",
+  "type": "object",
+  "properties": {
+    "global": {
+      "description": "Global settings used by XRd definitions",
+      "type": "object",
+      "properties": {
+        "labels": {
+          "description": "Labels added to every resource",
+          "type": "object"
+        },
+        "annotations": {
+          "description": "Annotations added to every resource",
+          "type": "object"
+        }
+      }
+    },
+    "nameOverride": {
+      "description": "Override the basename used when naming generated resources",
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "description": "Override the full name used when naming generated resources",
+      "type": "string"
+    },
+    "image": {
+      "description": "Container image config",
+      "type": "object",
+      "properties": {
+        "repository": {
+          "description": "Repository to pull the image from (required)",
+          "type": "string"
+        },
+        "tag": {
+          "description": "Image tag to pull from the repository (required)",
+          "type": "string"
+        },
+        "pullPolicy": {
+          "description": "Standard Kubernetes image pull policy",
+          "type": "string",
+          "default": "Always",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
+        },
+        "pullSecrets": {
+          "description": "Standard Kuberenetes pod imagePullSecrets array",
+          "type": "array"
+        }
+      },
+      "required": [
+        "repository",
+        "tag"
+      ],
+      "additionalProperties": false
+    },
+    "commonLabels": {
+      "description": "Labels added to every resource",
+      "type": "object"
+    },
+    "commonAnnotations": {
+      "description": "Annotations added to every resource",
+      "type": "object"
+    },
+    "labels": {
+      "description": "Labels added to the XRd deployment",
+      "type": "object"
+    },
+    "annotations": {
+      "description": "Annotations added to the XRd deployment",
+      "type": "object"
+    },
+    "resources": {
+      "description": "Standard Kubernetes container resources object",
+      "type": "object"
+    },
+    "securityContext": {
+      "description": "Standard Kubernetes container securityContext object",
+      "type": "object"
+    },
+    "hostNetwork": {
+      "description": "Flag indicating whether or not to use the host's network namespace",
+      "type": "boolean",
+      "default": false
+    },
+    "nodeSelector": {
+      "description": "Standard Kubernetes pod nodeSelector object",
+      "type": "object"
+    },
+    "tolerations": {
+      "description": "Standard Kubernetes pod tolerations array",
+      "type": "array"
+    },
+    "affinity": {
+      "description": "Standard Kubernetes pod affinity object",
+      "type": "object"
+    },
+    "podLabels": {
+      "description": "Labels added to the XRd pod",
+      "type": "object"
+    },
+    "podAnnotations": {
+      "description": "Annotations added to the XRd pod",
+      "type": "object"
+    },
+    "config": {
+      "description": "XRd configuration",
+      "type": "object",
+      "properties": {
+        "username": {
+          "description": "Username of a root user to add to the XR configuration",
+          "type": "string"
+        },
+        "password": {
+          "description": "Password for the root user (plaintext). Must be set if username is set",
+          "type": "string"
+        },
+        "ascii": {
+          "description": "ASCII XR configuration",
+          "type": "string"
+        },
+        "asciiEveryBoot": {
+          "description": "Flag indicating if the ASCII configuration should be applied on every boot (true), or just first boot (false)",
+          "type": "boolean",
+          "default": false
+        },
+        "script": {
+          "description": "XR boot script contents",
+          "type": "string"
+        },
+        "scriptEveryBoot": {
+          "description": "Flag indicating if the boot script should be run on every boot (true), or just first boot (false)",
+          "type": "boolean",
+          "default": false
+        },
+        "ztpEnable": {
+          "description": "Flag indicating if ZTP should be enabled",
+          "type": "boolean"
+        },
+        "ztpIni": {
+          "description": "Contents of a custom ZTP ini file to use. May only be set when ztpEnable is specified",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "persistence": {
+      "description": "Persistent storage settings",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable persistent storage",
+          "type": "boolean",
+          "default": true
+        },
+        "size": {
+          "description": "Size of the persistent storage volume",
+          "type": "string",
+          "default": "6Gi"
+        },
+        "accessModes": {
+          "description": "Persistent Volume access modes",
+          "type": "array",
+          "item": {
+            "type": "string"
+          }
+        },
+        "storageClass": {
+          "description": "Storage class for the persistent volume",
+          "type": "string"
+        },
+        "existingVolume": {
+          "description": "Use an existing Persistent Volume which must be created manually",
+          "type": "string"
+        },
+        "annotations": {
+          "description": "Annotations added to the PVC",
+          "type": "object"
+        },
+        "selector": {
+          "description": "Selector label query for the PVC",
+          "type": "object"
+        },
+        "dataSource": {
+          "description": "Custom PVC data source",
+          "type": "object"
+        },
+        "existingClaim": {
+          "description": "Use an existing Persistent Volume Claim which must be created manually",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "extraVolumes": {
+      "description": "Extra volumes for the XRd pod",
+      "type": "array",
+      "item": {
+        "type": "object"
+      }
+    },
+    "extraVolumeMounts": {
+      "description": "Extra volume mounts for the XRd container",
+      "type": "array",
+      "item": {
+        "type": "object"
+      }
+    },
+    "extraHostPathMounts": {
+      "description": "Extra hostpath mounts for the XRd container",
+      "type": "array",
+      "item": {
+        "description": "Information for a single host mount",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Unique name for the host mount",
+            "type": "string"
+          },
+          "hostPath": {
+            "description": "Path on the host to mount in the container",
+            "type": "string"
+          },
+          "mountPath": {
+            "description": "Path in the container mount the host directory",
+            "type": "string"
+          },
+          "create": {
+            "description": "Flag indicating whether or not to create the directory if it's missing on the host",
+            "type": "boolean",
+            "default": false
+          }
+        },
+        "required": [
+          "hostPath"
+        ]
+      }
+    },
+    "interfaces": {
+      "description": "Line interface settings",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "Underying interface type. Must be 'pci'",
+            "type": "string",
+            "enum": [
+              "pci"
+            ]
+          },
+          "config": {
+            "description": "Type-dependent configuration",
+            "type": "object"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "mgmtInterfaces": {
+      "description": "Management interface settings",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "Underying interface type. One of: 'defaultCni' or 'multus'",
+            "type": "string",
+            "enum": [
+              "defaultCni",
+              "multus"
+            ]
+          },
+          "config": {
+            "description": "Type-dependent configuration",
+            "type": "object"
+          },
+          "attachmentConfig": {
+            "description": "Network attachment annotation configuration, for multus-type interfaces only",
+            "type": "object"
+          },
+          "snoopIpv4Address": {
+            "description": "Indicate whether to snoop the pre-existing IPv4 address of the interface into XR config",
+            "type": "boolean",
+            "default": false
+          },
+          "snoopIpv4DefaultRoute": {
+            "description": "Indicate whether snoop the pre-existing IPv4 default route of the interface into XR config",
+            "type": "boolean",
+            "default": false
+          },
+          "snoopIpv6Address": {
+            "description": "Flag indicating whether to snoop the pre-existing IPv6 address of the interface into XR config",
+            "type": "boolean",
+            "default": false
+          },
+          "snoopIpv6DefaultRoute": {
+            "description": "Flag indicating whether to snoop the pre-existing IPv6 default route of the interface into XR config",
+            "type": "boolean",
+            "default": false
+          },
+          "chksum": {
+            "description": "Flag indicating whether TCP/UDP checksums must be calculated for XRd for ingress packets to counteract checksum offload",
+            "type": "boolean",
+            "default": false
+          },
+          "xrName": {
+            "description": "Customize the XR interface name for this interface",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "cpu": {
+      "description": "CPU settings",
+      "type": "object",
+      "properties": {
+        "cpuset": {
+          "description": "Override the full cpuset XRd runs on",
+          "type": "string"
+        },
+        "controlPlaneCpuCount": {
+          "description": "Override the number of CPUs assigned to the XRd control plane",
+          "type": "integer"
+        },
+        "hyperThreadingMode": {
+          "description": "HyperThreading mode for cpuset allocations",
+          "type": "string",
+          "enum": [
+            "off",
+            "pairs"
+          ],
+          "default": "off"
+        }
+      }
+    },
+    "pciDriver": {
+      "description": "PCI interface driver",
+      "type": "string",
+      "enum": [
+        "vfio-pci",
+        "igb_uio"
+      ],
+      "default": "vfio-pci"
+    },
+    "advancedSettings": {
+      "description": "Advanced settings for XRd not required for normal deployments",
+      "$comment": "XRd environment variables copied verbatim into the container environment",
+      "type": "object"
+    },
+    "xrd-common": {
+      "description": "Dummy placeholder for xrd-common subchart settings (never used)",
+      "type": "object"
+    }
+  },
+  "required": [
+    "image"
+  ],
+  "additionalProperties": false
+}

--- a/charts/xrd-vrouter/values.yaml
+++ b/charts/xrd-vrouter/values.yaml
@@ -1,0 +1,269 @@
+# Default values for XRd vRouter.
+#
+# There are two required fields which have no defaults and must
+# be specified for all installations:
+# - image.repository
+# - image.tag
+
+# Image configuration
+image:
+  # Repository for the container image (required).
+  #repository: ""
+  # Image tag (required).
+  #tag: ""
+  # Pull policy for images.
+  # One of "IfNotPresent", "Always", or "Never"
+  # See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+  pullPolicy: Always
+  # Image pull secrets.
+  # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  pullSecrets: []
+
+# Global configuration
+global:
+  # Labels to add to all deployed objects.
+  labels: {}
+
+  # Annotations to add to all deployed objects.
+  annotations: {}
+
+# Override the basename used for generated resources.
+#nameOverride: ""
+
+# Override the name used for generated resources.
+#fullnameOverride: ""
+
+# Labels to add to all deployed objects.
+commonLabels: {}
+
+# Annotations to add to all deployed objects.
+commonAnnotations: {}
+
+# Labels added to the XRd deployment.
+labels: {}
+
+# Annotations added to the XRd deployment.
+annotations: {}
+
+# Pod resource configuration.
+# See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+# The default resources are:
+#   - 5Gi memory request (unless a memory request/limit is specified here).
+#   - 3Gi hugepages-1Gi limit (and implicit request) (unless _any_ hugepage
+#     size request/limit is specified here).
+resources: {}
+# Example default resources for XRd vRouter:
+#  limits:
+#    hugepages-1Gi: 3Gi
+#  requests:
+#    memory: 5Gi
+
+# Security context for the XRd container.
+# Privileged mode is currently required for XRd in K8s due to device
+# access requirements.
+securityContext:
+  privileged: true
+
+# Use the host network namespace.
+hostNetwork: false
+
+# Location control for the XRd pod.
+# Standard K8s configuration, more information available at:
+# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+# Node labels for pod assignment.
+nodeSelector: {}
+# List of node taints to tolerate.
+tolerations: []
+# Affinity for pod assignment.
+affinity: {}
+
+# Labels added to the XRd pod.
+podLabels: {}
+
+# Annotations added to the XRd pod.
+podAnnotations: {}
+
+# Persistent storage controls.
+persistence:
+  # Enable persistent storage.
+  enabled: false
+  # Persistent Volume size.
+  size: "6Gi"
+  # Persistent volume access modes.
+  accessModes:
+  - ReadWriteOnce
+  # Storage class for the persistent volume.
+  # This storage class must be defined separately.
+  # N.B Not specifying a storage class is not the same as specifying an
+  # empty string! (https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+  #storageClass: ""
+  # Bind to an existing Persistent Volume.
+  # If specified this must be a pre-existing PV that is not bound.
+  #existingVolume: ""
+  # Annotations added to the PVC.
+  annotations: {}
+  # Selector for the PVC.
+  #selector: {}
+  # Custom PVC data source.
+  #dataSource: {}
+  # Use an existing bound Persistent Volume Claim.
+  # If specified this must be a pre-existing PVC that is bound.
+  # This overrides any other settings in this section.
+  #existingClaim: ""
+
+# Extra volume definitions for the XRd pod.
+# These are added verbatim to the XRd pod volumes.
+extraVolumes: []
+
+# Extra volume mounts for the XRd container.
+# These are added verbatim to the XRd container volume mounts.
+extraVolumeMounts: []
+
+# Extra host path mounts for the XRd container.
+# This can be used to mount additional host paths into the container instead
+# of defining an extraVolumes entry and an extraVolumeMounts entry.
+extraHostPathMounts: []
+  # Unique name (required)
+  #- name: e810-driver
+  # Path from the host to mount in the container (required)
+  #hostPath: "/lib/firmware/intel/ice/ddp"
+  # Path to use as the mount point in the container (defaults to the same
+  # as the hostPath).
+  #mountPath: ""
+  # Flag indicating whether or not to create the directory if it doesn't
+  # exist at container start (default false).
+  #create: false
+
+# XR configuration and boot scripts.
+config:
+  # Username and password for the root system user.
+  # This field can be used instead of putting the user configuration in
+  # the ascii configuration below so values files can be distributed
+  # without username and password data.
+  # This MUST NOT clash with the ASCII config below!
+  # These must be specified together, i.e. both or neither must be specified.
+  #username: ""
+  #password: ""
+  # ASCII XR configuration to be applied on XR boot.
+  #ascii: ""
+  # Flag indicating when the above configuration should be applied:
+  #  - false indicates only on first boot.
+  #  - true indicates on every boot.
+  # Defaults to false (only first boot).
+  #asciiEveryBoot: false
+  # Contents of a script to run on XR boot.
+  #script: ""
+  # Flag indicating when the above script should be run:
+  #  - false indicates only on first boot.
+  #  - true indicates on every boot.
+  # Defaults to false (only first boot).
+  #scriptEveryBoot: false
+  # ZTP enable flag.
+  ztpEnable: false
+  # Contents of a custom ZTP ini file to use.
+  # This may only be set when the ztpEnable flag is set to 'true'
+  #ztpIni: ""
+
+# XRd interfaces.
+# These are split into two arrays:
+#  - An array of line interfaces: 'interfaces'
+#  - An array of management interfaces: 'mgmtInterfaces'
+#
+# Each of these is an array of interface objects.
+# Interfaces can be one of the following types:
+#  - defaultCni: This interface connects to the defaultCNI veth interface
+#                created in each pod.
+#                Only one interface of this type may be specified (across both
+#                interfaces and mgmtInterfaces).
+#                This can be specified as a mgmtInterface only.
+#  - multus:     This connects to an interface created using a CNI plugin,
+#                driven by the multus meta-CNI plugin.
+#                All of the network attachment definition configuration must be
+#                specified under the 'config' field for the interface.
+#                Any attachment annotation configuration may be specified under
+#                the 'attachmentConfig' field.
+#                This can be specified as a mgmtInterface only.
+#  - pci:        This connects to a PCI interface, or range of PCI interfaces.
+#                The configuration here is one of:
+#                - device: <address>, to use the single interface at the
+#                  given PCI address.
+#                - first: N, to use the first N network PCI devices.
+#                - last: N, to use the final N network PCI devices.
+#                This can be specified as a line interface only.
+#                N.B. If PCI interfaces are specified with "first" or "last",
+#                that must be the ONLY "pci" interface definition.
+#
+# On 'defaultCni' and 'multus' interfaces, the following options may also
+# be specified to control the interface behavior in XR:
+#   - chksum: Turn on TCP/UDP checksum calculation for ingress packets (to
+#             counteract checksum offload to hardware).
+#   - xrName: Customize the XR interface name for this interface.
+#   - snoopIpv4Address: see below.
+#   - snoopIpv4DefaultRoute: see below.
+#   - snoopIpv6Address: see below.
+#   - snoopIpv6Address: see below.
+# The snooping options find the named configuration item in the
+# container network namespace and apply that configuration into XR, e.g.
+# if snoopIpv4Address is specified, the IPv4 address for the underlying
+# linux interface is found, and XR configuration for that IPv4 address
+# on the corresponding XR interface is generated and applied on XRd startup.
+#
+# XRd line interfaces.
+interfaces: []
+# Example interfaces:
+#  config:
+#    device: 00.06.00:1
+#- type pci
+#  config:
+#    last: 3
+
+# XRd management interfaces.
+mgmtInterfaces: []
+# Example interfaces:
+#- type: defaultCni
+#  snoopIpv4Address: true
+#  snoopIpv4DefaultRoute: true
+#  chksum: true
+#- type: multus
+#  config:
+#    type: macvlan
+#    master: eth1
+#    mode: bridge
+#    ipam:
+#      type: static
+#  attachmentConfig:
+#    ips:
+#    - "10.0.0.1/24"
+
+# CPU settings.
+# More information about the CPU behavior of XRd vRouter can be found
+# here: @@@
+cpu: {}
+  # Override the cpuset to use for XRd.
+  # This must be a subset of the CPUs available for XRd to run on.
+  #cpuset: ""
+  # Override the number of CPUs used for control-plane threads from
+  # the pool of CPUs in the XRd cpuset.
+  #controlPlaneCpuCount: 2
+  # HyperThreading mode.
+  # This option must be used when the CPU has hyperthreading turned on
+  # in order to ensure the dataplane has whole physical CPU cores and prevent
+  # 'noisy neighbor' issues.
+  # This mode supports two values:
+  #  - 'off' - no hyperthreading (default)
+  #  - 'pairs' - where hyperthreaded siblings are consecutive, i.e.
+  #               * physical core 0 has logical cores 0 and 1
+  #               * physical core 1 has logical cores 2 and 3
+  #               * etc...
+  #hyperThreadingMode: "off"
+
+# PCI interface driver.
+# Two PCI drivers are supported:
+#  - 'vfio-pci' (default)
+#  - 'igb_uio'
+#pciDriver: "vfio-pci"
+
+# XRd advanced settings.
+# This section contains settings not required by most users.
+# Details can be found here: @@@
+advancedSettings: {}

--- a/scripts/chart-releaser
+++ b/scripts/chart-releaser
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# chart-releaser - wrapper around helm/chart-releaser-action
+
+set -e
+
+
+trap 'rm -rf .cr*' ERR
+trap 'rm -rf .cr*' EXIT
+
+
+mkdir -p .cr
+curl -o .cr/cr.sh https://raw.githubusercontent.com/helm/chart-releaser-action/main/cr.sh
+chmod +x .cr/cr.sh
+
+
+RUNNER_TOOL_CACHE=.cr .cr/cr.sh "$@"

--- a/scripts/commit-check
+++ b/scripts/commit-check
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# commit-check - Pre-commit checks
+
+set -e -o pipefail
+
+
+FAILURES=0
+
+
+echo "Running helm lint..."
+args=("--set" "image.repository=repository" "--set" "image.tag=latest")
+error=false
+for chart in charts/*; do
+    pushd "$chart"
+    if ! (helm dependency update && helm lint "${args[@]}"); then
+        error=true
+    fi
+    popd
+done
+if [ $error = true ]; then
+    FAILURES=$((FAILURES+1))
+    echo "helm lint failed, check output and fix errors" >&2
+fi
+
+
+echo
+echo "Running shellcheck..."
+if ! shellcheck scripts/{chart-releaser,commit-check}; then
+    echo "shellcheck failed, check output and fix issues." >&2
+    FAILURES=$((FAILURES+1))
+fi
+
+
+echo
+if ((FAILURES > 0)); then
+    echo "ERROR: There were $FAILURES failures"
+    exit 1
+else
+    echo "SUCCESS: All passed!"
+    exit 0
+fi


### PR DESCRIPTION
Add XRd Helm charts v1.0.0-beta.1.

Notable additions:

* Added example values.yaml files - https://github.com/ios-xr/xrd-helm/pull/1/commits/9e411fd53bbd1511c87b829439d768512e56c2f1 - `ct lint` looks in hardcoded locations for any values.yaml files, and fails if `image.repository/tag` is not given.
* Added config files in .github/config for ct and yamllint - https://github.com/ios-xr/xrd-helm/pull/1/commits/8c787c1420c6d30af0c31d93410ecf83c9679e1a and https://github.com/ios-xr/xrd-helm/pull/1/commits/192f519dd124bfd5dfb2e5850d93368aa1586b97