### PR TITLE
Fix NOTES for xrd-control-plane and xrd-vrouter

### DIFF
--- a/charts/xrd-control-plane/Chart.yaml
+++ b/charts/xrd-control-plane/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - xrd
 sources:
 - https://github.com/ios-xr/xrd-helm
-version: 1.0.0-beta.1
+version: 1.0.0-beta.2
 dependencies:
 - name: xrd-common
   version: 1.0.0-beta.1

--- a/charts/xrd-control-plane/templates/NOTES.txt
+++ b/charts/xrd-control-plane/templates/NOTES.txt
@@ -1,1 +1,1 @@
-You have installed XRd Control Plane version {{ .Values.tag }}.
+You have installed XRd Control Plane version {{ .Values.image.tag }}.

--- a/charts/xrd-vrouter/Chart.yaml
+++ b/charts/xrd-vrouter/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
  - xrd
 sources:
  - https://github.com/ios-xr/xrd-helm
-version: 1.0.0-beta.1
+version: 1.0.0-beta.2
 dependencies:
 - name: xrd-common
   version: 1.0.0-beta.1

--- a/charts/xrd-vrouter/templates/NOTES.txt
+++ b/charts/xrd-vrouter/templates/NOTES.txt
@@ -1,1 +1,1 @@
-You have installed XRd vRouter version {{ .Values.tag }}.
+You have installed XRd vRouter version {{ .Values.image.tag }}.


### PR DESCRIPTION
Both `xrd-control-plane` and `xrd-vrouter` print `.Values.tag` in their installation notes, but this should be `.Values.image.tag`.