### PR TITLE
Fix whitespace chomping issue in immutable labels

### DIFF
--- a/.github/config/ct-version-increment.yml
+++ b/.github/config/ct-version-increment.yml
@@ -1,0 +1,7 @@
+# ct-version-increment.yml - Chart-testing configuration for version
+#                            increment checks.
+---
+check-version-increment: true
+validate-chart-schema: false
+validate-maintainers: false
+validate-yaml: false

--- a/.github/config/ct.yml
+++ b/.github/config/ct.yml
@@ -1,3 +1,6 @@
+# ct.yml - Chart-testing configuration.
+---
+check-version-increment: false
 excluded-charts: xrd-common
 lint-conf: .github/config/yamllint.yml
 validate-maintainers: false

--- a/.github/workflows/sa.yml
+++ b/.github/workflows/sa.yml
@@ -42,7 +42,7 @@ jobs:
         run: ct lint --config .github/config/ct.yml --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Run chart-testing (check-version-increment)
-        run: ct lint --config .github/config/ct-verison-increment.yml --target-branch ${{ github.event.repository.default_branch }}
+        run: ct lint --config .github/config/ct-version-increment.yml --target-branch ${{ github.event.repository.default_branch }}
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/sa.yml
+++ b/.github/workflows/sa.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run chart-testing (lint)
         run: ct lint --config .github/config/ct.yml --target-branch ${{ github.event.repository.default_branch }}
 
+      - name: Run chart-testing (check-version-increment)
+        run: ct lint --config .github/config/ct-verison-increment.yml --target-branch ${{ github.event.repository.default_branch }}
+
   shellcheck:
     runs-on: ubuntu-latest
     name: 'bash-sa (shellcheck)'

--- a/charts/xrd-common/Chart.yaml
+++ b/charts/xrd-common/Chart.yaml
@@ -8,4 +8,4 @@ keywords:
  - xrd
 sources:
  - https://github.com/ios-xr/xrd-helm
-version: 1.0.0-beta.3
+version: 1.0.0-beta.2

--- a/charts/xrd-common/Chart.yaml
+++ b/charts/xrd-common/Chart.yaml
@@ -8,4 +8,4 @@ keywords:
  - xrd
 sources:
  - https://github.com/ios-xr/xrd-helm
-version: 1.0.0-beta.2
+version: 1.0.0-beta.3

--- a/charts/xrd-common/templates/_helpers.tpl
+++ b/charts/xrd-common/templates/_helpers.tpl
@@ -67,7 +67,7 @@ Common labels for immutable resources
 {{- include "xrd.selectorLabels" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- with (merge .Values.commonLabels .Values.global.labels) }}
-{{- toYaml . }}
+{{ toYaml . }}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
`xrd.commonImmutableLabels` incorrectly chomps a newlines when joining `app.kubernetes.io/managed-by: Helm`  and common/global labels.

Also: split the `ct lint` Github actions in two - one which lints the application charts fully (library charts cannot be linted), and one which just checks the version of all charts (`xrd-common` included) has incremented when necessary.  This fixes an issue in CI where committing changes to `xrd-common` without a version bump was allowed.

E.g:

```
$ cat test.yaml
image:
  repository: foo
  tag: bar
global:
  labels:
    one: two
persistence:
  enabled: true
$ helm template charts/xrd-control-plane -f test.yaml
Error: YAML parse error on xrd-control-plane/templates/statefulset.yaml: error converting YAML to JSON: yaml: line 74: mapping values are not allowed in this context

Use --debug flag to render out invalid YAML
```

Testing:

```
$ helm template charts/xrd-control-plane -f test.yaml > /dev/null
$ echo $?
0