### PR TITLE
Add enabled flag and template XR config

### DIFF
--- a/charts/xrd-common/Chart.yaml
+++ b/charts/xrd-common/Chart.yaml
@@ -8,4 +8,4 @@ keywords:
  - xrd
 sources:
  - https://github.com/ios-xr/xrd-helm
-version: 1.0.1
+version: 1.0.2

--- a/charts/xrd-common/templates/_config-configmap.tpl
+++ b/charts/xrd-common/templates/_config-configmap.tpl
@@ -23,7 +23,7 @@ data:
      password {{ .Values.config.password }}
     !
     {{- end }}
-    {{- .Values.config.ascii | default "" | nindent 4 }}
+    {{- tpl .Values.config.ascii . | default "" | nindent 4 }}
   {{- end }}
   {{- if .Values.config.script }}
   startup.sh: |

--- a/charts/xrd-control-plane/Chart.yaml
+++ b/charts/xrd-control-plane/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
 - xrd
 sources:
 - https://github.com/ios-xr/xrd-helm
-version: 1.0.1
+version: 1.0.2
 dependencies:
 - name: xrd-common
-  version: 1.0.1
+  version: 1.0.2
   repository: "file://../xrd-common"

--- a/charts/xrd-control-plane/values.schema.json
+++ b/charts/xrd-control-plane/values.schema.json
@@ -5,6 +5,11 @@
   "description": "Configuration values for XRd helm charts",
   "type": "object",
   "properties": {
+    "enabled": {
+        "description": "Allow this chart to be used as an optional subchart",
+        "type": "boolean",
+        "default": true
+    },
     "global": {
       "description": "Global settings used by XRd definitions",
       "type": "object",

--- a/charts/xrd-vrouter/Chart.yaml
+++ b/charts/xrd-vrouter/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
  - xrd
 sources:
  - https://github.com/ios-xr/xrd-helm
-version: 1.0.1
+version: 1.0.2
 dependencies:
 - name: xrd-common
-  version: 1.0.1
+  version: 1.0.2
   repository: "file://../xrd-common"

--- a/charts/xrd-vrouter/values.schema.json
+++ b/charts/xrd-vrouter/values.schema.json
@@ -5,6 +5,11 @@
   "description": "Configuration values for XRd helm charts",
   "type": "object",
   "properties": {
+    "enabled": {
+        "description": "Allow this chart to be used as an optional subchart",
+        "type": "boolean",
+        "default": true
+    },
     "global": {
       "description": "Global settings used by XRd definitions",
       "type": "object",


### PR DESCRIPTION
Add `enabled` flag to the JSONSchema for XRd vRouter and ControlPlane charts, so that they may be used as optional subcharts (see https://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags).

This flag is deliberately hidden - i.e. not exposed in values.yaml.

Also template the XR ascii config.  See https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function.