### PR TITLE
Add additional cpuset options

### DIFF
--- a/charts/xrd-vrouter/Chart.yaml
+++ b/charts/xrd-vrouter/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
  - xrd
 sources:
  - https://github.com/ios-xr/xrd-helm
-version: 1.0.3
+version: 1.0.4
 dependencies:
 - name: xrd-common
   version: 1.0.3

--- a/charts/xrd-vrouter/templates/statefulset.yaml
+++ b/charts/xrd-vrouter/templates/statefulset.yaml
@@ -55,14 +55,32 @@ Construct the resources including the default if that resource wasn't specified.
 
 {{- /* Generate CPU env vars */}}
 {{- if .Values.cpu }}
-  {{- with .Values.cpu.cpuset }}
-    {{- $_ := set $env "XR_VROUTER_CPUSET" . }}
-  {{- end }}
-  {{- with .Values.cpu.controlPlaneCpuCount }}
-    {{- $_ := set $env "XR_VROUTER_CP_NUM_CPUS" . }}
-  {{- end }}
-  {{- with .Values.cpu.hyperThreadingMode }}
-    {{- $_ := set $env "XR_VROUTER_HT_MODE" . }}
+  {{- with .Values.cpu}}
+    {{- if and .controlPlaneCpuset (not .dataPlaneCpuset)}}
+      {{- fail "controlPlaneCpuset is set but dataPlaneCpuset is not set" }}
+    {{- end }}
+    {{- if and .dataPlaneCpuset (not .controlPlaneCpuset)}}
+      {{- fail "dataPlaneCpuset is set but controlPlaneCpuset is not set" }}
+    {{- end }}
+    {{- if and .controlPlaneCpuset .dataPlaneCpuset}}
+      {{- if .cpuset }}
+        {{- fail "cpuset is set but controlPlaneCpuset and dataPlaneCpuset are also set" }}
+      {{- end }}
+      {{- if .controlPlaneCpuCount }}
+        {{- fail "controlPlaneCpuCount is set but controlPlaneCpuset and dataPlaneCpuset are also set" }}
+      {{- end }}
+      {{- $_ := set $env "XR_VROUTER_DP_CPUSET" .dataPlaneCpuset }}
+      {{- $_ := set $env "XR_VROUTER_CP_CPUSET" .controlPlaneCpuset }}
+    {{- end }}
+    {{- if .cpuset }}
+      {{- $_ := set $env "XR_VROUTER_CPUSET" .cpuset }}
+    {{- end }}
+    {{- if .controlPlaneCpuCount }}
+      {{- $_ := set $env "XR_VROUTER_CP_NUM_CPUS" .controlPlaneCpuCount }}a
+    {{- end }}
+    {{- if .hyperThreadingMode }}
+      {{- $_ := set $env "XR_VROUTER_HT_MODE" .hyperThreadingMode }}
+    {{- end }}
   {{- end }}
 {{- end }}
 

--- a/charts/xrd-vrouter/templates/statefulset.yaml
+++ b/charts/xrd-vrouter/templates/statefulset.yaml
@@ -69,6 +69,9 @@ Construct the resources including the default if that resource wasn't specified.
       {{- if .controlPlaneCpuCount }}
         {{- fail "controlPlaneCpuCount must not be set if controlPlaneCpuset and dataPlaneCpuset are set" }}
       {{- end }}
+       {{- if .hyperThreadingMode }}
+        {{- fail "hyperThreadingMode must not be set if controlPlaneCpuset and dataPlaneCpuset are set" }}
+      {{- end }}
       {{- $_ := set $env "XR_VROUTER_DP_CPUSET" .dataPlaneCpuset }}
       {{- $_ := set $env "XR_VROUTER_CP_CPUSET" .controlPlaneCpuset }}
     {{- end }}

--- a/charts/xrd-vrouter/templates/statefulset.yaml
+++ b/charts/xrd-vrouter/templates/statefulset.yaml
@@ -57,17 +57,17 @@ Construct the resources including the default if that resource wasn't specified.
 {{- if .Values.cpu }}
   {{- with .Values.cpu}}
     {{- if and .controlPlaneCpuset (not .dataPlaneCpuset)}}
-      {{- fail "controlPlaneCpuset is set but dataPlaneCpuset is not set" }}
+      {{- fail "dataPlaneCpuset must be set if controlPlaneCpuset is set" }}
     {{- end }}
     {{- if and .dataPlaneCpuset (not .controlPlaneCpuset)}}
-      {{- fail "dataPlaneCpuset is set but controlPlaneCpuset is not set" }}
+      {{- fail "controlPlaneCpuset must be set if dataPlaneCpuset is set" }}
     {{- end }}
     {{- if and .controlPlaneCpuset .dataPlaneCpuset}}
       {{- if .cpuset }}
-        {{- fail "cpuset is set but controlPlaneCpuset and dataPlaneCpuset are also set" }}
+        {{- fail "cpuset must not be set if controlPlaneCpuset and dataPlaneCpuset are set" }}
       {{- end }}
       {{- if .controlPlaneCpuCount }}
-        {{- fail "controlPlaneCpuCount is set but controlPlaneCpuset and dataPlaneCpuset are also set" }}
+        {{- fail "controlPlaneCpuCount must not be set if controlPlaneCpuset and dataPlaneCpuset are set" }}
       {{- end }}
       {{- $_ := set $env "XR_VROUTER_DP_CPUSET" .dataPlaneCpuset }}
       {{- $_ := set $env "XR_VROUTER_CP_CPUSET" .controlPlaneCpuset }}

--- a/charts/xrd-vrouter/values.schema.json
+++ b/charts/xrd-vrouter/values.schema.json
@@ -334,11 +334,11 @@
       "type": "object",
       "properties": {
         "controlPlaneCpuset": {
-          "description": "CPUset for the XRd control plane to use",
+          "description": "cpuset for the XRd control-plane to use",
           "type": "string"
         },
         "dataPlaneCpuset": {
-          "description": "CPUset for the XRd data plane to use",
+          "description": "cpuset for the XRd dataplane to use",
           "type": "string"
         },
         "cpuset": {

--- a/charts/xrd-vrouter/values.schema.json
+++ b/charts/xrd-vrouter/values.schema.json
@@ -333,6 +333,14 @@
       "description": "CPU settings",
       "type": "object",
       "properties": {
+        "controlPlaneCpuset": {
+          "description": "CPUset for the XRd control plane to use",
+          "type": "string"
+        },
+        "dataPlaneCpuset": {
+          "description": "CPUset for the XRd data plane to use",
+          "type": "string"
+        },
         "cpuset": {
           "description": "Override the full cpuset XRd runs on",
           "type": "string"

--- a/charts/xrd-vrouter/values.yaml
+++ b/charts/xrd-vrouter/values.yaml
@@ -236,12 +236,12 @@ mgmtInterfaces: []
 #    - "10.0.0.1/24"
 
 # CPU settings.
-# More information about the CPU behavior of XRd vRouter can be found
-# here: @@@
 cpu: {}
-  # Specify the cpusets for XRd to use for the control plane and the data
-  # plane. They must each be a subset of the CPUs available for XRd to run on.
+  # Specify the cpusets for XRd to use for the control-plane and the dataplane.
+  # They must each be a subset of the CPUs available for XRd to run on.
   # Both or neither must be specified.
+  # If neither is specified then all available CPUs are used, split
+  # appropriately between the control-plane and dataplane.
   #controlPlaneCpuset: ""
   #dataPlaneCpuset: ""
   # HyperThreading mode.
@@ -259,11 +259,14 @@ cpu: {}
   # Deprecated cpu settings:
   #
   # Override the cpuset to use for XRd. Must not be used in conjunction with
-  # controlPlaneCpuset and dataPlaneCpuset. (Deprecated.)
+  # controlPlaneCpuset and dataPlaneCpuset.
+  # Deprecated. Use controlPlaneCpuset and dataPlaneCpuset instead.
   # This must be a subset of the CPUs available for XRd to run on.
   #cpuset: ""
   # Override the number of CPUs used for control-plane threads from the pool of
-  # CPUs in the XRd cpuset, used in conjunction with cpuset. (Deprecated.)
+  # CPUs in the XRd cpuset. Must not be used in conjunction with
+  # controlPlaneCpuset and dataPlaneCpuset.
+  # Deprecated. Use controlPlaneCpuset and dataPlaneCpuset instead.
   #controlPlaneCpuCount: 2
 
 # PCI interface driver.

--- a/charts/xrd-vrouter/values.yaml
+++ b/charts/xrd-vrouter/values.yaml
@@ -244,6 +244,19 @@ cpu: {}
   # appropriately between the control-plane and dataplane.
   #controlPlaneCpuset: ""
   #dataPlaneCpuset: ""
+  # HyperThreading mode.
+  # This option can be used when the CPU has hyperthreading turned on to ensure
+  # that the dataplane has whole physical CPU cores and to prevent 'noisy
+  # neighbor' issues.
+  # This mode supports two values:
+  #  - 'off' - no hyperthreading (default)
+  #  - 'pairs' - where hyperthreaded siblings are consecutive, i.e.
+  #               * physical core 0 has logical cores 0 and 1
+  #               * physical core 1 has logical cores 2 and 3
+  #               * etc...
+  # Must not be used in conjunction with controlPlaneCpuset and
+  # dataPlaneCpuset.
+  #hyperThreadingMode: "off"
   #
   # Deprecated cpu settings:
   #
@@ -257,20 +270,6 @@ cpu: {}
   # controlPlaneCpuset and dataPlaneCpuset.
   # Deprecated. Use controlPlaneCpuset and dataPlaneCpuset instead.
   #controlPlaneCpuCount: 2
-  # HyperThreading mode.
-  # This option must be used when the CPU has hyperthreading turned on
-  # in order to ensure the dataplane has whole physical CPU cores and prevent
-  # 'noisy neighbor' issues.
-  # This mode supports two values:
-  #  - 'off' - no hyperthreading (default)
-  #  - 'pairs' - where hyperthreaded siblings are consecutive, i.e.
-  #               * physical core 0 has logical cores 0 and 1
-  #               * physical core 1 has logical cores 2 and 3
-  #               * etc...
-  # Must not be used in conjunction with controlPlaneCpuset and
-  # dataPlaneCpuset.
-  # Deprecated. Use controlPlaneCpuset and dataPlaneCpuset instead.
-  #hyperThreadingMode: "off"
 
 # PCI interface driver.
 # Two PCI drivers are supported:

--- a/charts/xrd-vrouter/values.yaml
+++ b/charts/xrd-vrouter/values.yaml
@@ -239,12 +239,11 @@ mgmtInterfaces: []
 # More information about the CPU behavior of XRd vRouter can be found
 # here: @@@
 cpu: {}
-  # Override the cpuset to use for XRd.
-  # This must be a subset of the CPUs available for XRd to run on.
-  #cpuset: ""
-  # Override the number of CPUs used for control-plane threads from
-  # the pool of CPUs in the XRd cpuset.
-  #controlPlaneCpuCount: 2
+  # Specify the cpusets for XRd to use for the control plane and the data
+  # plane. They must each be a subset of the CPUs available for XRd to run on.
+  # Both or neither must be specified.
+  #controlPlaneCpuset: ""
+  #dataPlaneCpuset: ""
   # HyperThreading mode.
   # This option must be used when the CPU has hyperthreading turned on
   # in order to ensure the dataplane has whole physical CPU cores and prevent
@@ -256,6 +255,16 @@ cpu: {}
   #               * physical core 1 has logical cores 2 and 3
   #               * etc...
   #hyperThreadingMode: "off"
+  #
+  # Deprecated cpu settings:
+  #
+  # Override the cpuset to use for XRd. Must not be used in conjunction with
+  # controlPlaneCpuset and dataPlaneCpuset. (Deprecated.)
+  # This must be a subset of the CPUs available for XRd to run on.
+  #cpuset: ""
+  # Override the number of CPUs used for control-plane threads from the pool of
+  # CPUs in the XRd cpuset, used in conjunction with cpuset. (Deprecated.)
+  #controlPlaneCpuCount: 2
 
 # PCI interface driver.
 # Two PCI drivers are supported:

--- a/charts/xrd-vrouter/values.yaml
+++ b/charts/xrd-vrouter/values.yaml
@@ -244,6 +244,19 @@ cpu: {}
   # appropriately between the control-plane and dataplane.
   #controlPlaneCpuset: ""
   #dataPlaneCpuset: ""
+  #
+  # Deprecated cpu settings:
+  #
+  # Override the cpuset to use for XRd. Must not be used in conjunction with
+  # controlPlaneCpuset and dataPlaneCpuset.
+  # This must be a subset of the CPUs available for XRd to run on.
+  # Deprecated. Use controlPlaneCpuset and dataPlaneCpuset instead.
+  #cpuset: ""
+  # Override the number of CPUs used for control-plane threads from the pool of
+  # CPUs in the XRd cpuset. Must not be used in conjunction with
+  # controlPlaneCpuset and dataPlaneCpuset.
+  # Deprecated. Use controlPlaneCpuset and dataPlaneCpuset instead.
+  #controlPlaneCpuCount: 2
   # HyperThreading mode.
   # This option must be used when the CPU has hyperthreading turned on
   # in order to ensure the dataplane has whole physical CPU cores and prevent
@@ -254,20 +267,10 @@ cpu: {}
   #               * physical core 0 has logical cores 0 and 1
   #               * physical core 1 has logical cores 2 and 3
   #               * etc...
+  # Must not be used in conjunction with controlPlaneCpuset and
+  # dataPlaneCpuset.
+  # Deprecated. Use controlPlaneCpuset and dataPlaneCpuset instead.
   #hyperThreadingMode: "off"
-  #
-  # Deprecated cpu settings:
-  #
-  # Override the cpuset to use for XRd. Must not be used in conjunction with
-  # controlPlaneCpuset and dataPlaneCpuset.
-  # Deprecated. Use controlPlaneCpuset and dataPlaneCpuset instead.
-  # This must be a subset of the CPUs available for XRd to run on.
-  #cpuset: ""
-  # Override the number of CPUs used for control-plane threads from the pool of
-  # CPUs in the XRd cpuset. Must not be used in conjunction with
-  # controlPlaneCpuset and dataPlaneCpuset.
-  # Deprecated. Use controlPlaneCpuset and dataPlaneCpuset instead.
-  #controlPlaneCpuCount: 2
 
 # PCI interface driver.
 # Two PCI drivers are supported:

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,5 +20,5 @@ The unit tests can be run using any container manager.  For example, using Docke
 
 ```
 docker build . -t helm-tests
-docker run -v "$PWD/../:/charts" helm-tests bats tests/ut/xrd-[control-plane or vrouter]
+docker run -v "$PWD/../:/charts" helm-tests bats tests/ut/[host-check, xrd-control-plane or xrd-vrouter]
 ```

--- a/tests/ut/xrd-vrouter/statefulset.bats
+++ b/tests/ut/xrd-vrouter/statefulset.bats
@@ -334,16 +334,34 @@ setup_file () {
     assert_query_equal '.spec.template.spec.containers[0].env[3].value' "6144"
 }
 
-@test "vRouter StatefulSet: cpu set container env var can be set" {
-    template --set 'cpu.cpuset=foo'
-    assert_query_equal '.spec.template.spec.containers[0].env[3].name' "XR_VROUTER_CPUSET"
-    assert_query_equal '.spec.template.spec.containers[0].env[3].value' "foo"
+@test "vRouter StatefulSet: XR_VROUTER_CP_CPUSET and XR_VROUTER_DP_CPUSET can be set" {
+    template --set 'cpu.controlPlaneCpuset=foo' --set 'cpu.dataPlaneCpuset=bar'
+    assert_query_equal '[.spec.template.spec.containers[0].env | map(select(.name == "XR_VROUTER_CP_CPUSET"))][0][0].value' "foo"
+    assert_query_equal '[.spec.template.spec.containers[0].env | map(select(.name == "XR_VROUTER_DP_CPUSET"))][0][0].value' "bar"
 }
 
-@test "vRouter StatefulSet: control plane cpu count container env var can be set" {
-    template --set 'cpu.controlPlaneCpuCount=10'
-    assert_query_equal '.spec.template.spec.containers[0].env[3].name' "XR_VROUTER_CP_NUM_CPUS"
-    assert_query_equal '.spec.template.spec.containers[0].env[3].value' "10"
+@test "vRouter StatefulSet: dataPlaneCpuset must be set if controlPlaneCpuset is" {
+    template_failure --set 'cpu.controlPlaneCpuset=bar'
+    assert_error_message_contains "controlPlaneCpuset is set but dataPlaneCpuset is not set"
+}
+
+@test "vRouter StatefulSet: controlPlaneCpuset must be set if dataPlaneCpuset is" {
+    template_failure --set 'cpu.dataPlaneCpuset=bar'
+    assert_error_message_contains "dataPlaneCpuset is set but controlPlaneCpuset is not set"
+}
+
+@test "vRouter StatefulSet: cpuset can't be specified if controlPlaneCpuset and dataPlaneCpuset are" {
+    template_failure --set 'cpu.cpuset=foo' \
+        --set 'cpu.controlPlaneCpuset=bar' \
+        --set 'cpu.dataPlaneCpuset=baz'
+    assert_error_message_contains "cpuset is set but controlPlaneCpuset and dataPlaneCpuset are also set"
+}
+
+@test "vRouter StatefulSet: controlPlaneCpuCount can't be specified if controlPlaneCpuset and dataPlaneCpuset are" {
+    template_failure --set 'cpu.controlPlaneCpuCount=1' \
+        --set 'cpu.controlPlaneCpuset=foo'\
+        --set 'cpu.dataPlaneCpuset=bar'
+    assert_error_message_contains "controlPlaneCpuCount is set but controlPlaneCpuset and dataPlaneCpuset are also set"
 }
 
 @test "vRouter StatefulSet: hyperthreading mode container env var can be set" {

--- a/tests/ut/xrd-vrouter/statefulset.bats
+++ b/tests/ut/xrd-vrouter/statefulset.bats
@@ -364,6 +364,13 @@ setup_file () {
     assert_error_message_contains "controlPlaneCpuCount must not be set if controlPlaneCpuset and dataPlaneCpuset are set"
 }
 
+@test "vRouter StatefulSet: hyperThreadingMode can't be specified if controlPlaneCpuset and dataPlaneCpuset are" {
+    template_failure --set 'cpu.hyperThreadingMode=off' \
+        --set 'cpu.controlPlaneCpuset=foo'\
+        --set 'cpu.dataPlaneCpuset=bar'
+    assert_error_message_contains "hyperThreadingMode must not be set if controlPlaneCpuset and dataPlaneCpuset are set"
+}
+
 @test "vRouter StatefulSet: hyperthreading mode container env var can be set" {
     template --set 'cpu.hyperThreadingMode=off'
     assert_query_equal '.spec.template.spec.containers[0].env[4].name' "XR_VROUTER_HT_MODE"

--- a/tests/ut/xrd-vrouter/statefulset.bats
+++ b/tests/ut/xrd-vrouter/statefulset.bats
@@ -342,26 +342,26 @@ setup_file () {
 
 @test "vRouter StatefulSet: dataPlaneCpuset must be set if controlPlaneCpuset is" {
     template_failure --set 'cpu.controlPlaneCpuset=bar'
-    assert_error_message_contains "controlPlaneCpuset is set but dataPlaneCpuset is not set"
+    assert_error_message_contains "dataPlaneCpuset must be set if controlPlaneCpuset is set"
 }
 
 @test "vRouter StatefulSet: controlPlaneCpuset must be set if dataPlaneCpuset is" {
     template_failure --set 'cpu.dataPlaneCpuset=bar'
-    assert_error_message_contains "dataPlaneCpuset is set but controlPlaneCpuset is not set"
+    assert_error_message_contains "controlPlaneCpuset must be set if dataPlaneCpuset is set"
 }
 
 @test "vRouter StatefulSet: cpuset can't be specified if controlPlaneCpuset and dataPlaneCpuset are" {
     template_failure --set 'cpu.cpuset=foo' \
         --set 'cpu.controlPlaneCpuset=bar' \
         --set 'cpu.dataPlaneCpuset=baz'
-    assert_error_message_contains "cpuset is set but controlPlaneCpuset and dataPlaneCpuset are also set"
+    assert_error_message_contains "cpuset must not be set if controlPlaneCpuset and dataPlaneCpuset are set"
 }
 
 @test "vRouter StatefulSet: controlPlaneCpuCount can't be specified if controlPlaneCpuset and dataPlaneCpuset are" {
     template_failure --set 'cpu.controlPlaneCpuCount=1' \
         --set 'cpu.controlPlaneCpuset=foo'\
         --set 'cpu.dataPlaneCpuset=bar'
-    assert_error_message_contains "controlPlaneCpuCount is set but controlPlaneCpuset and dataPlaneCpuset are also set"
+    assert_error_message_contains "controlPlaneCpuCount must not be set if controlPlaneCpuset and dataPlaneCpuset are set"
 }
 
 @test "vRouter StatefulSet: hyperthreading mode container env var can be set" {


### PR DESCRIPTION
Add `controlPlaneCpuset` and `dataPlaneCpuset` Helm options and mark cpuset as deprecated.

UT written and manual testing as below.

Manual Helm:
```
...
cpu:
  controlPlaneCpuset: 0-3
  dataPlaneCpuset: 4-7
```
In `describe pod`:
```
...
Environment:
      XR_ENV_VARS_VERSION:        1
      XR_FIRST_BOOT_CONFIG:       /etc/xrd/startup.cfg
      XR_INTERFACES:
      XR_MGMT_INTERFACES:
      XR_VROUTER_CP_CPUSET:       0-3
      XR_VROUTER_DP_CPUSET:       4-7
      XR_VROUTER_DP_HUGEPAGE_MB:  3072
...
```
In XR logs
```
CPU assignments
  available cpuset: node0 0-31, node1 32-63
  control-plane cpuset: 0-3
  dataplane main cpuset: 4
  dataplane packet cpuset: 5-7 (rx:5 tx:6 wk:7)
```