### PR TITLE
Fix cpu count env var error

### DIFF
--- a/charts/xrd-vrouter/Chart.yaml
+++ b/charts/xrd-vrouter/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
  - xrd
 sources:
  - https://github.com/ios-xr/xrd-helm
-version: 1.0.4
+version: 1.0.5
 dependencies:
 - name: xrd-common
   version: 1.0.3

--- a/charts/xrd-vrouter/templates/statefulset.yaml
+++ b/charts/xrd-vrouter/templates/statefulset.yaml
@@ -79,7 +79,7 @@ Construct the resources including the default if that resource wasn't specified.
       {{- $_ := set $env "XR_VROUTER_CPUSET" .cpuset }}
     {{- end }}
     {{- if .controlPlaneCpuCount }}
-      {{- $_ := set $env "XR_VROUTER_CP_NUM_CPUS" .controlPlaneCpuCount }}a
+      {{- $_ := set $env "XR_VROUTER_CP_NUM_CPUS" .controlPlaneCpuCount }}
     {{- end }}
     {{- if .hyperThreadingMode }}
       {{- $_ := set $env "XR_VROUTER_HT_MODE" .hyperThreadingMode }}

--- a/tests/ut/xrd-vrouter/statefulset.bats
+++ b/tests/ut/xrd-vrouter/statefulset.bats
@@ -350,11 +350,21 @@ setup_file () {
     assert_error_message_contains "controlPlaneCpuset must be set if dataPlaneCpuset is set"
 }
 
+@test "vRouter StatefulSet: cpuset can be set" {
+    template --set 'cpu.cpuset=foo'
+    assert_query_equal '[.spec.template.spec.containers[0].env | map(select(.name == "XR_VROUTER_CPUSET"))][0][0].value' "foo"
+}
+
 @test "vRouter StatefulSet: cpuset can't be specified if controlPlaneCpuset and dataPlaneCpuset are" {
     template_failure --set 'cpu.cpuset=foo' \
         --set 'cpu.controlPlaneCpuset=bar' \
         --set 'cpu.dataPlaneCpuset=baz'
     assert_error_message_contains "cpuset must not be set if controlPlaneCpuset and dataPlaneCpuset are set"
+}
+
+@test "vRouter StatefulSet: controlPlaneCpuCount can be set" {
+    template --set 'cpu.controlPlaneCpuCount=1'
+    assert_query_equal '[.spec.template.spec.containers[0].env | map(select(.name == "XR_VROUTER_CP_NUM_CPUS"))][0][0].value' "1"
 }
 
 @test "vRouter StatefulSet: controlPlaneCpuCount can't be specified if controlPlaneCpuset and dataPlaneCpuset are" {


### PR DESCRIPTION
Additional character accidentally included in Helm chart.
Revealed a testing gap due to tests accidentally being deleted - now fixed.