### PR TITLE
Change Helm charts to use secret instead of password.

### DIFF
--- a/charts/xrd-common/Chart.yaml
+++ b/charts/xrd-common/Chart.yaml
@@ -8,4 +8,4 @@ keywords:
  - xrd
 sources:
  - https://github.com/ios-xr/xrd-helm
-version: 1.0.3
+version: 1.0.4

--- a/charts/xrd-common/templates/_config-configmap.tpl
+++ b/charts/xrd-common/templates/_config-configmap.tpl
@@ -18,7 +18,7 @@ data:
     username {{ .Values.config.username }}
      group root-lr
      group cisco-support
-     password {{ .Values.config.password }}
+     secret {{ .Values.config.password }}
     !
     {{- end }}
     {{- if (get .Values.config "ascii") }}

--- a/charts/xrd-control-plane/Chart.yaml
+++ b/charts/xrd-control-plane/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
 - xrd
 sources:
 - https://github.com/ios-xr/xrd-helm
-version: 1.0.3
+version: 1.0.4
 dependencies:
 - name: xrd-common
-  version: 1.0.3
+  version: 1.0.4
   repository: "file://../xrd-common"

--- a/charts/xrd-vrouter/Chart.yaml
+++ b/charts/xrd-vrouter/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
  - xrd
 sources:
  - https://github.com/ios-xr/xrd-helm
-version: 1.0.5
+version: 1.0.6
 dependencies:
 - name: xrd-common
-  version: 1.0.3
+  version: 1.0.4
   repository: "file://../xrd-common"

--- a/tests/ut/xrd-control-plane/configmap.bats
+++ b/tests/ut/xrd-control-plane/configmap.bats
@@ -71,7 +71,7 @@ setup_file () {
 @test "Control Plane ConfigMap: Startup config can be set using username and password" {
     template --set 'config.username=foo' --set 'config.password=bar'
     assert_query_equal '.data."startup.cfg"' \
-        "username foo\n group root-lr\n group cisco-support\n password bar\n!"
+        "username foo\n group root-lr\n group cisco-support\n secret bar\n!"
 }
 
 @test "Control Plane ConfigMap: password must be set if username is" {

--- a/tests/ut/xrd-vrouter/configmap.bats
+++ b/tests/ut/xrd-vrouter/configmap.bats
@@ -71,7 +71,7 @@ setup_file () {
 @test "vRouter ConfigMap: Startup config can be set using username and password" {
     template --set 'config.username=foo' --set 'config.password=bar'
     assert_query_equal '.data."startup.cfg"' \
-        "username foo\n group root-lr\n group cisco-support\n password bar\n!"
+        "username foo\n group root-lr\n group cisco-support\n secret bar\n!"
 }
 
 @test "vRouter ConfigMap: password must be set if username is" {


### PR DESCRIPTION
`password` XR config is being deprecated in favour of `secret`. Update the Helm charts to use `secret` instead of `password`.

UT written for all changes

Tested manually on vRouter and Control Plane images (XR version 7.7).