### PR TITLE
Remove containers used in commit checks after running

### DIFF
--- a/scripts/commit-check
+++ b/scripts/commit-check
@@ -68,7 +68,7 @@ podman build tests/ -t helm-tests --network host
 
 echo
 echo "Running host-check unit tests..."
-if ! podman run -v "$PWD/:/charts" helm-tests bats tests/ut/host-check; then
+if ! podman run --rm -v "$PWD/:/charts" helm-tests bats tests/ut/host-check; then
     echo "host-check unit tests failed, check output and fix issues." >&2
     FAILURES=$((FAILURES+1))
 else
@@ -77,7 +77,7 @@ fi
 
 echo
 echo "Running Control Plane unit tests..."
-if ! podman run -v "$PWD/:/charts" helm-tests bats tests/ut/xrd-control-plane; then
+if ! podman run --rm -v "$PWD/:/charts" helm-tests bats tests/ut/xrd-control-plane; then
     echo "Control Plane unit tests failed, check output and fix issues." >&2
     FAILURES=$((FAILURES+1))
 else
@@ -86,7 +86,7 @@ fi
 
 echo
 echo "Running vRouter unit tests..."
-if ! podman run -v "$PWD/:/charts" helm-tests bats tests/ut/xrd-vrouter; then
+if ! podman run --rm -v "$PWD/:/charts" helm-tests bats tests/ut/xrd-vrouter; then
     echo "vRouter unit tests failed, check output and fix issues." >&2
     FAILURES=$((FAILURES+1))
 else

--- a/scripts/commit-check
+++ b/scripts/commit-check
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
 # This script runs all commit checks EXCEPT for checking that the version is
-# correctly incermented, which is done via a seperate github action.
+# correctly incremented, which is done via a separate github action.
 
 set -e
 
+# shellcheck disable=SC2317
 function cleanup()
 {
     echo

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,5 +20,5 @@ The unit tests can be run using any container manager.  For example, using Docke
 
 ```
 docker build . -t helm-tests
-docker run -v "$PWD/../:/charts" helm-tests bats tests/ut/[host-check, xrd-control-plane or xrd-vrouter]
+docker run --rm -v "$PWD/../:/charts" helm-tests bats tests/ut/[host-check, xrd-control-plane or xrd-vrouter]
 ```


### PR DESCRIPTION
### Summary

Remove containers used in commit checks after running to prevent dead containers from accumulating.

Testing: manual testing confirms change works.

### Checklist

- [ ] Version incremented
  <!-- The Helm charts in this repo use semantic versioning and the version must be increased for any change. -->
- [ ] Changelog updated
  <!-- The changelog must be updated for any version change. -->
- [ ] Version compatibility matrix updated (or not required)
  <!-- The version compatibility matrix must be updated for any major or minor version change. -->
- [ ] Static analysis and tests passing
   - See `tests/README.md` for details.
