### PR TITLE
Add option to configure additional CNI plugins for sriov and multus interface types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 The v2 release supports Cisco IOS-XR release version 24.4.1 and above.
 
+#### v2.1.0
+
+- Add `additionalCNIConfig` option under SR-IOV and Multus interfaces for configuring additional CNI plugins
+
 #### v2.0.0
 
 - Change `cpu.hyperThreadingMode` options, adding `auto` and removing `off`.
@@ -19,3 +23,7 @@ The v1 release supports Cisco IOS-XR release versions from 7.7.1 to 24.3.1.
 ### v1 (active)
 
 The v1 release supports Cisco IOS-XR release versions 7.7.1 and above.
+
+#### v1.2.0
+
+- Add `additionalCNIConfig` option under SR-IOV and Multus interfaces for configuring additional CNI plugins

--- a/charts/xrd-common/Chart.yaml
+++ b/charts/xrd-common/Chart.yaml
@@ -8,4 +8,4 @@ keywords:
  - xrd
 sources:
  - https://github.com/ios-xr/xrd-helm
-version: 1.1.0
+version: 1.2.0

--- a/charts/xrd-common/templates/_interfaces.tpl
+++ b/charts/xrd-common/templates/_interfaces.tpl
@@ -66,7 +66,7 @@ or an empty string otherwise.
 
 {{- define "xrd.interfaces.linuxflags" -}}
 {{- $flags := list }}
-{{- $base := list "type" "config" "attachmentConfig" "resource" }}
+{{- $base := list "type" "config" "attachmentConfig" "resource" "additionalCNIConfig" }}
 {{- range $k, $v := . -}}
   {{- if eq $k "snoopIpv4Address" }}
     {{- if $v }}
@@ -113,7 +113,7 @@ or an empty string otherwise.
 
 {{- define "xrd.interfaces.sriovflags" -}}
 {{- $flags := list }}
-{{- $base := list "type" "config" "resource" }}
+{{- $base := list "type" "config" "resource" "additionalCNIConfig" }}
 {{- range $k, $v := . -}}
   {{- if not (has $k $base) }}
     {{- fail (printf "%s may not be specified for sriov interfaces" $k) }}

--- a/charts/xrd-common/templates/_network-attachments.tpl
+++ b/charts/xrd-common/templates/_network-attachments.tpl
@@ -24,9 +24,7 @@ spec:
     {
       "cniVersion": "0.3.1",
       "name": "{{ include "xrd.fullname" $ }}-{{ $cniIndex }}",
-      "plugins": [
-        {{- $intf.config | toPrettyJson | nindent 8 }}
-      ]
+      "plugins": {{- prepend ( $intf.additionalCNIConfig | default list ) $intf.config | toPrettyJson | nindent 8 }}
     }
 ...
 {{- $cniIndex = add1 $cniIndex}}

--- a/charts/xrd-control-plane/Chart.yaml
+++ b/charts/xrd-control-plane/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
 - xrd
 sources:
 - https://github.com/ios-xr/xrd-helm
-version: 1.1.0
+version: 1.2.0
 dependencies:
 - name: xrd-common
-  version: 1.1.0
+  version: 1.2.0
   repository: "file://../xrd-common"

--- a/charts/xrd-control-plane/templates/_interfaces.tpl
+++ b/charts/xrd-control-plane/templates/_interfaces.tpl
@@ -10,6 +10,9 @@
     {{- if hasKey . "attachmentConfig" }}
       {{- fail "attachmentConfig may not be specified for defaultCni interfaces" }}
     {{- end }}
+    {{- if hasKey . "additionalCNIConfig" }}
+      {{- fail "additionalCNIConfig may not be specified for PCI interfaces" }}
+    {{- end }}
     {{- if hasKey . "resource" }}
       {{- fail "resource may not be specified for defaultCni interface types" }}
     {{- end }}
@@ -53,6 +56,9 @@
   {{- if eq .type "defaultCni" }}
     {{- if hasKey . "attachmentConfig" }}
       {{- fail "attachmentConfig may not be specified for defaultCni mgmt interfaces" }}
+    {{- end }}
+    {{- if hasKey . "additionalCNIConfig" }}
+      {{- fail "additionalCNIConfig may not be specified for PCI interfaces" }}
     {{- end }}
     {{- if hasKey . "resource" }}
       {{- fail "resource may not be specified for defaultCni mgmt interface types" }}

--- a/charts/xrd-control-plane/values.schema.json
+++ b/charts/xrd-control-plane/values.schema.json
@@ -270,6 +270,13 @@
             "description": "Type-dependent configuration",
             "type": "object"
           },
+          "additionalCNIConfig": {
+            "description": "Config for additional CNI pluginsm for multus and sriov-type interfaces only",
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
           "attachmentConfig": {
             "description": "Network attachment annotation configuration, for multus-type interfaces only",
             "type": "object"
@@ -332,6 +339,13 @@
           "config": {
             "description": "Type-dependent configuration",
             "type": "object"
+          },
+          "additionalCNIConfig": {
+            "description": "Config for additional CNI pluginsm for multus and sriov-type interfaces only",
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
           },
           "attachmentConfig": {
             "description": "Network attachment annotation configuration, for multus-type interfaces only",

--- a/charts/xrd-control-plane/values.yaml
+++ b/charts/xrd-control-plane/values.yaml
@@ -204,6 +204,10 @@ config:
 # linux interface is found, and XR configuration for that IPv4 address
 # on the corresponding XR interface is generated and applied on XRd startup.
 #
+# On 'sriov' and 'multus' interfaces and management interfaces, config for
+# additional CNI plugins can be specified under the 'additionalCNIConfig' field.
+# This is a list of CNI plugin configurations to be applied in order.
+#
 # XRd line interfaces.
 interfaces: []
 # Example interfaces:
@@ -217,6 +221,17 @@ interfaces: []
 #  config:
 #    type: sriov
 #    vlan: 1
+#- type: sriov
+#  resource: intel.com/intel_sriov_netdevice_2
+#  config:
+#    type: sriov
+#    vlan: 1
+#  additionalCNIConfig:
+#  - type: tuning
+#    capabilities:
+#      mac: true
+#    allmulti: true
+#    promisc: true
 
 # XRd management interfaces.
 mgmtInterfaces: []
@@ -236,7 +251,7 @@ mgmtInterfaces: []
 #    ips:
 #    - "10.0.0.1/24"
 #- type: sriov
-#  resource: intel.com/intel_sriov_netdevice_2
+#  resource: intel.com/intel_sriov_netdevice_3
 #  config:
 #    type: sriov
 

--- a/charts/xrd-vrouter/Chart.yaml
+++ b/charts/xrd-vrouter/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
  - xrd
 sources:
  - https://github.com/ios-xr/xrd-helm
-version: 2.0.0
+version: 2.1.0
 dependencies:
 - name: xrd-common
-  version: 1.1.0
+  version: 1.2.0
   repository: "file://../xrd-common"

--- a/charts/xrd-vrouter/templates/_interfaces.tpl
+++ b/charts/xrd-vrouter/templates/_interfaces.tpl
@@ -11,6 +11,9 @@
     {{- if hasKey . "attachmentConfig" }}
       {{- fail "attachmentConfig may not be specified for PCI interfaces" }}
     {{- end }}
+    {{- if hasKey . "additionalCNIConfig" }}
+      {{- fail "additionalCNIConfig may not be specified for PCI interfaces" }}
+    {{- end }}
     {{- if hasKey . "resource" }}
       {{- fail "resource may not be specified for PCI interfaces" }}
     {{- end }}
@@ -87,6 +90,9 @@
   {{- if eq .type "defaultCni" }}
     {{- if hasKey . "attachmentConfig" }}
       {{- fail "attachmentConfig may not be specified for defaultCni mgmt interface types" }}
+    {{- end }}
+    {{- if hasKey . "additionalCNIConfig" }}
+      {{- fail "additionalCNIConfig may not be specified for PCI interfaces" }}
     {{- end }}
     {{- if (hasKey . "xrName") }}
       {{- fail "xrName may not be specified for interfaces on XRd vRouter" }}

--- a/charts/xrd-vrouter/values.schema.json
+++ b/charts/xrd-vrouter/values.schema.json
@@ -272,6 +272,13 @@
           "config": {
             "description": "Type-dependent configuration",
             "type": "object"
+          },
+          "additionalCNIConfig": {
+            "description": "Config for additional CNI pluginsm for sriov-type interfaces only",
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
           }
         },
         "required": [
@@ -298,6 +305,13 @@
           "config": {
             "description": "Type-dependent configuration",
             "type": "object"
+          },
+          "additionalCNIConfig": {
+            "description": "Config for additional CNI pluginsm for sriov and multus-type interfaces only",
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
           },
           "attachmentConfig": {
             "description": "Network attachment annotation configuration, for multus-type interfaces only",

--- a/charts/xrd-vrouter/values.yaml
+++ b/charts/xrd-vrouter/values.yaml
@@ -219,6 +219,10 @@ config:
 # linux interface is found, and XR configuration for that IPv4 address
 # on the corresponding XR interface is generated and applied on XRd startup.
 #
+# On 'sriov' and 'multus' interfaces and management interfaces, config for
+# additional CNI plugins can be specified under the 'additionalCNIConfig' field.
+# This is a list of CNI plugin configurations to be applied in order.
+#
 # XRd line interfaces.
 interfaces: []
 # Example interfaces:
@@ -232,6 +236,17 @@ interfaces: []
 #  config:
 #    type: sriov
 #    vlan: 1
+#- type: sriov
+#  resource: intel.com/intel_sriov_netdevice_2
+#  config:
+#    type: sriov
+#    vlan: 1
+#  additionalCNIConfig:
+#  - type: tuning
+#    capabilities:
+#      mac: true
+#    allmulti: true
+#    promisc: true
 
 # XRd management interfaces.
 mgmtInterfaces: []
@@ -250,6 +265,11 @@ mgmtInterfaces: []
 #  attachmentConfig:
 #    ips:
 #    - "10.0.0.1/24"
+#- type: sriov
+#  resource: intel.com/intel_sriov_netdevice_2
+#  config:
+#    type: sriov
+#  snoopIpv4Address: true
 #- type: sriov
 #  resource: intel.com/intel_sriov_netdevice_2
 #  config:

--- a/tests/ut/xrd-control-plane/network-attachments.bats
+++ b/tests/ut/xrd-control-plane/network-attachments.bats
@@ -72,19 +72,19 @@ setup_file () {
 @test "Control Plane NetworkAttachmentDefinition: Check default config" {
     template --set-json 'interfaces=[{"type": "multus"}]'
     assert_query_equal '.spec.config' \
-        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-control-plane-0\",\n  \"plugins\": [\n    null\n  ]\n}"
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-control-plane-0\",\n  \"plugins\":\n    [\n      null\n    ]\n}"
 }
 
 @test "Control Plane NetworkAttachmentDefinition: Config can be set for MGMT interfaces" {
     template --set-json 'mgmtInterfaces=[{"type": "multus", "config": {"foo": "bar"}}]'
     assert_query_equal '.spec.config'\
-        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-control-plane-0\",\n  \"plugins\": [\n    {\n      \"foo\": \"bar\"\n    }\n  ]\n}"
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-control-plane-0\",\n  \"plugins\":\n    [\n      {\n        \"foo\": \"bar\"\n      }\n    ]\n}"
 }
 
 @test "Control Plane NetworkAttachmentDefinition: Config can be set for interfaces" {
     template --set-json 'interfaces=[{"type": "multus", "config": {"foo": "bar"}}]'
     assert_query_equal '.spec.config' \
-        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-control-plane-0\",\n  \"plugins\": [\n    {\n      \"foo\": \"bar\"\n    }\n  ]\n}"
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-control-plane-0\",\n  \"plugins\":\n    [\n      {\n        \"foo\": \"bar\"\n      }\n    ]\n}"
 }
 
 @test "Control Plane NetworkAttachmentDefinition: No interfaces" {
@@ -180,7 +180,7 @@ setup_file () {
 @test "Control Plane NetworkAttachmentDefinition (sriov): Config can be set" {
     template --set-json 'interfaces=[{"type": "sriov", "resource": "foo", "config": {"type": "sriov"}}]'
     assert_query_equal '.spec.config' \
-        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-control-plane-0\",\n  \"plugins\": [\n    {\n      \"type\": \"sriov\"\n    }\n  ]\n}"
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-control-plane-0\",\n  \"plugins\":\n    [\n      {\n        \"type\": \"sriov\"\n      }\n    ]\n}"
 }
 
 @test "Control Plane NetworkAttachmentDefinition: multiple sriov interfaces can be created together" {
@@ -200,4 +200,52 @@ setup_file () {
     template --set-json 'mgmtInterfaces=[{"type": "sriov", "resource": "foo", "config": {"type": "sriov"}}]'
     assert_query_equal '.metadata.name' \
         "release-name-xrd-control-plane-0"
+}
+
+@test "Control Plane NetworkAttachmentDefinition (sriov): Additional CNI config can be set" {
+    template --set-json 'interfaces=[{"type": "sriov", "resource": "foo", "config": {"type": "sriov"}, "additionalCNIConfig": [{"bar": "baz"}]}]'
+    assert_query_equal '.spec.config' \
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-control-plane-0\",\n  \"plugins\":\n    [\n      {\n        \"type\": \"sriov\"\n      },\n      {\n        \"bar\": \"baz\"\n      }\n    ]\n}"
+}
+
+@test "Control Plane NetworkAttachmentDefinition (sriov): Multiple additional CNI config can be set" {
+    template --set-json 'interfaces=[{"type": "sriov", "resource": "foo", "config": {"type": "sriov"}, "additionalCNIConfig": [{"bar": "baz"}, {"qux": "quux"}]}]'
+    assert_query_equal '.spec.config' \
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-control-plane-0\",\n  \"plugins\":\n    [\n      {\n        \"type\": \"sriov\"\n      },\n      {\n        \"bar\": \"baz\"\n      },\n      {\n        \"qux\": \"quux\"\n      }\n    ]\n}"
+}
+
+@test "Control Plane NetworkAttachmentDefinition (sriov mgmt): Additional CNI config can be set" {
+    template --set-json 'mgmtInterfaces=[{"type": "sriov", "resource": "foo", "config": {"type": "sriov"}, "additionalCNIConfig": [{"bar": "baz"}]}]'
+    assert_query_equal '.spec.config' \
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-control-plane-0\",\n  \"plugins\":\n    [\n      {\n        \"type\": \"sriov\"\n      },\n      {\n        \"bar\": \"baz\"\n      }\n    ]\n}"
+}
+
+@test "Control Plane NetworkAttachmentDefinition (sriov mgmt): Multiple additional CNI config can be set" {
+    template --set-json 'mgmtInterfaces=[{"type": "sriov", "resource": "foo", "config": {"type": "sriov"}, "additionalCNIConfig": [{"bar": "baz"}, {"qux": "quux"}]}]'
+    assert_query_equal '.spec.config' \
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-control-plane-0\",\n  \"plugins\":\n    [\n      {\n        \"type\": \"sriov\"\n      },\n      {\n        \"bar\": \"baz\"\n      },\n      {\n        \"qux\": \"quux\"\n      }\n    ]\n}"
+}
+
+@test "Control Plane NetworkAttachmentDefinition (multus): Additional CNI config can be set" {
+    template --set-json 'interfaces=[{"type": "multus", "config": {"foo": "bar"}, "additionalCNIConfig": [{"baz": "qux"}]}]'
+    assert_query_equal '.spec.config' \
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-control-plane-0\",\n  \"plugins\":\n    [\n      {\n        \"foo\": \"bar\"\n      },\n      {\n        \"baz\": \"qux\"\n      }\n    ]\n}"
+}
+
+@test "Control Plane NetworkAttachmentDefinition (multus): Multiple additional CNI config can be set" {
+    template --set-json 'interfaces=[{"type": "multus", "config": {"foo": "bar"}, "additionalCNIConfig": [{"baz": "qux"}, {"quux": "corge"}]}]'
+    assert_query_equal '.spec.config' \
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-control-plane-0\",\n  \"plugins\":\n    [\n      {\n        \"foo\": \"bar\"\n      },\n      {\n        \"baz\": \"qux\"\n      },\n      {\n        \"quux\": \"corge\"\n      }\n    ]\n}"
+}
+
+@test "Control Plane NetworkAttachmentDefinition (multus mgmt): Additional CNI config can be set" {
+    template --set-json 'mgmtInterfaces=[{"type": "multus", "config": {"foo": "bar"}, "additionalCNIConfig": [{"baz": "qux"}]}]'
+    assert_query_equal '.spec.config' \
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-control-plane-0\",\n  \"plugins\":\n    [\n      {\n        \"foo\": \"bar\"\n      },\n      {\n        \"baz\": \"qux\"\n      }\n    ]\n}"
+}
+
+@test "Control Plane NetworkAttachmentDefinition (multus mgmt): Multiple additional CNI config can be set" {
+    template --set-json 'mgmtInterfaces=[{"type": "multus", "config": {"foo": "bar"}, "additionalCNIConfig": [{"baz": "qux"}, {"quux": "corge"}]}]'
+    assert_query_equal '.spec.config' \
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-control-plane-0\",\n  \"plugins\":\n    [\n      {\n        \"foo\": \"bar\"\n      },\n      {\n        \"baz\": \"qux\"\n      },\n      {\n        \"quux\": \"corge\"\n      }\n    ]\n}"
 }

--- a/tests/ut/xrd-vrouter/network-attachments.bats
+++ b/tests/ut/xrd-vrouter/network-attachments.bats
@@ -66,13 +66,13 @@ setup_file () {
 @test "vRouter NetworkAttachmentDefinition (multus): Check default config" {
     template --set-json 'mgmtInterfaces=[{"type": "multus"}]'
     assert_query_equal '.spec.config' \
-        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-vrouter-0\",\n  \"plugins\": [\n    null\n  ]\n}"
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-vrouter-0\",\n  \"plugins\":\n    [\n      null\n    ]\n}"
 }
 
 @test "vRouter NetworkAttachmentDefinition (multus): Config can be set" {
     template --set-json 'mgmtInterfaces=[{"type": "multus", "config": {"foo": "bar"}}]'
     assert_query_equal '.spec.config' \
-        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-vrouter-0\",\n  \"plugins\": [\n    {\n      \"foo\": \"bar\"\n    }\n  ]\n}"
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-vrouter-0\",\n  \"plugins\":\n    [\n      {\n        \"foo\": \"bar\"\n      }\n    ]\n}"
 }
 
 @test "vRouter NetworkAttachmentDefinition (sriov): Name consists of the release name, template name and index" {
@@ -133,7 +133,7 @@ setup_file () {
 @test "vRouter NetworkAttachmentDefinition (sriov): Config can be set" {
     template --set-json 'interfaces=[{"type": "sriov", "resource": "foo", "config": {"type": "sriov"}}]'
     assert_query_equal '.spec.config' \
-        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-vrouter-0\",\n  \"plugins\": [\n    {\n      \"type\": \"sriov\"\n    }\n  ]\n}"
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-vrouter-0\",\n  \"plugins\":\n    [\n      {\n        \"type\": \"sriov\"\n      }\n    ]\n}"
 }
 
 @test "vRouter NetworkAttachmentDefinition: multiple sriov interfaces can be created together" {
@@ -191,4 +191,40 @@ setup_file () {
 @test "vRouter NetworkAttachmentDefinition: error if unknown mgmt interface type is requested" {
     template_failure --set-json 'mgmtInterfaces=[{"type": "foo"}]'
     assert_error_message_contains "must be one of the following: \"defaultCni\", \"multus\", \"sriov\""
+}
+
+@test "vRouter NetworkAttachmentDefinition (sriov): Additional CNI config can be set" {
+    template --set-json 'interfaces=[{"type": "sriov", "resource": "foo", "config": {"type": "sriov"}, "additionalCNIConfig": [{"bar": "baz"}]}]'
+    assert_query_equal '.spec.config' \
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-vrouter-0\",\n  \"plugins\":\n    [\n      {\n        \"type\": \"sriov\"\n      },\n      {\n        \"bar\": \"baz\"\n      }\n    ]\n}"
+}
+
+@test "vRouter NetworkAttachmentDefinition (sriov): Multiple additional CNI config can be set" {
+    template --set-json 'interfaces=[{"type": "sriov", "resource": "foo", "config": {"type": "sriov"}, "additionalCNIConfig": [{"bar": "baz"}, {"qux": "quux"}]}]'
+    assert_query_equal '.spec.config' \
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-vrouter-0\",\n  \"plugins\":\n    [\n      {\n        \"type\": \"sriov\"\n      },\n      {\n        \"bar\": \"baz\"\n      },\n      {\n        \"qux\": \"quux\"\n      }\n    ]\n}"
+}
+
+@test "vRouter NetworkAttachmentDefinition (sriov mgmt): Additional CNI config can be set" {
+    template --set-json 'mgmtInterfaces=[{"type": "sriov", "resource": "foo", "config": {"type": "sriov"}, "additionalCNIConfig": [{"bar": "baz"}]}]'
+    assert_query_equal '.spec.config' \
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-vrouter-0\",\n  \"plugins\":\n    [\n      {\n        \"type\": \"sriov\"\n      },\n      {\n        \"bar\": \"baz\"\n      }\n    ]\n}"
+}
+
+@test "vRouter NetworkAttachmentDefinition (sriov mgmt): Multiple additional CNI config can be set" {
+    template --set-json 'mgmtInterfaces=[{"type": "sriov", "resource": "foo", "config": {"type": "sriov"}, "additionalCNIConfig": [{"bar": "baz"}, {"qux": "quux"}]}]'
+    assert_query_equal '.spec.config' \
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-vrouter-0\",\n  \"plugins\":\n    [\n      {\n        \"type\": \"sriov\"\n      },\n      {\n        \"bar\": \"baz\"\n      },\n      {\n        \"qux\": \"quux\"\n      }\n    ]\n}"
+}
+
+@test "vRouter NetworkAttachmentDefinition (multus): Additional CNI config can be set" {
+    template --set-json 'mgmtInterfaces=[{"type": "multus", "config": {"foo": "bar"}, "additionalCNIConfig": [{"baz": "qux"}]}]'
+    assert_query_equal '.spec.config' \
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-vrouter-0\",\n  \"plugins\":\n    [\n      {\n        \"foo\": \"bar\"\n      },\n      {\n        \"baz\": \"qux\"\n      }\n    ]\n}"
+}
+
+@test "vRouter NetworkAttachmentDefinition (multus): Multiple additional CNI config can be set" {
+    template --set-json 'mgmtInterfaces=[{"type": "multus", "config": {"foo": "bar"}, "additionalCNIConfig": [{"baz": "qux"}, {"quux": "corge"}]}]'
+    assert_query_equal '.spec.config' \
+        "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"release-name-xrd-vrouter-0\",\n  \"plugins\":\n    [\n      {\n        \"foo\": \"bar\"\n      },\n      {\n        \"baz\": \"qux\"\n      },\n      {\n        \"quux\": \"corge\"\n      }\n    ]\n}"
 }


### PR DESCRIPTION
### Summary

Add the ability to configure additional plugins in NetworkAttachmentDefinitions (NADs) generated by Helm. This applies to both interface types for which NADs are generated, `multus` and `sriov` and to both management and data interfaces.

Additional config is supplied under a new `additionalCNIConfig` key under the interface specification, which accepts a list of config object. See the `values.yaml` files for an example.

Additional UT has been written to test this new config item, all UT passes.

Manual testing with the tuning plugin has been done for both XRd vRouter and Control Plane, confirming that the correct NADs are applied on `helm install` and, in the case of Control Plane, that the config has the expected effect.

### Checklist

- [Y] Version incremented
  <!-- The Helm charts in this repo use semantic versioning and the version must be increased for any change. -->
- [Y] Changelog updated
  <!-- The changelog must be updated for any version change. -->
- [NA] Version compatibility matrix updated (or not required)
  <!-- The version compatibility matrix must be updated for any major or minor version change. -->
- [Y] Static analysis and tests passing
   - See `tests/README.md` for details.
